### PR TITLE
Vectorized power_per_bin_calc_fast, program now 30x faster

### DIFF
--- a/Emis3D_Main/Emis3D.py
+++ b/Emis3D_Main/Emis3D.py
@@ -8,34 +8,37 @@ Created on Mon Apr 10 15:55:26 2023
 
 import sys
 from os import listdir, remove
-from os.path import dirname, realpath, isfile, join
-        
+from os.path import dirname, isdir, isfile, join, realpath
+
 FILE_PATH = dirname(realpath(__file__))
 EMIS3D_PARENT_DIRECTORY = dirname(dirname(FILE_PATH))
-EMIS3D_UNIVERSAL_MAIN_DIRECTORY = join(EMIS3D_PARENT_DIRECTORY,\
-    "Emis3D_Universal", "Emis3D_Main")
+EMIS3D_UNIVERSAL_MAIN_DIRECTORY = join(
+    EMIS3D_PARENT_DIRECTORY, "Emis3D_Universal", "Emis3D_Main"
+)
 EMIS3D_INPUTS_DIRECTORY = join(EMIS3D_PARENT_DIRECTORY, "Emis3D_JET", "Emis3D_Inputs")
 
 import math
-import numpy as np
-import matplotlib.pyplot as plt
-from matplotlib.ticker import FormatStrFormatter
-from Util import RedChi2_To_Pvalue
-from scipy.optimize import minimize, curve_fit
 from copy import copy
 
+import matplotlib.pyplot as plt
+import numpy as np
+from matplotlib.ticker import FormatStrFormatter
+from scipy.optimize import curve_fit, minimize
+from Util import RedChi2_To_Pvalue
+
+
 class Emis3D(object):
-    
+
     def __init__(self, TorSegmented=False):
-        
-        self.torSegmented=TorSegmented
+
+        self.torSegmented = TorSegmented
         self.allRadDistsVec = []
-        self.tokamakAMode = None # Always loaded
-        self.tokamakBMode = None # Not loaded unless necessary; time consuming
+        self.tokamakAMode = None  # Always loaded
+        self.tokamakBMode = None  # Not loaded unless necessary; time consuming
         self.load_tokamak(Mode="Analysis")
-        
+
         self.numTorLocs = self.tokamakAMode.numTorLocs
-        
+
         # In calc_fits
         self.chisqVec = None
         self.pvalVec = None
@@ -54,54 +57,65 @@ class Emis3D(object):
         self.minFitsFirsts = None
         self.minFitsSeconds = None
         self.extrasPowers = None
-        
+
     def load_raddists(self, TokamakName):
-        
+
         self.allRadDistsVec = []
-        
+
         if TokamakName == "JET":
             # returns all files in self.raddist_directories_to_load
             onlyfiles = []
             for directory in self.raddist_directories_to_load:
-                raddistfiles = [join(directory,f) for f in listdir(directory)\
-                         if isfile(join(directory, f))]
+                raddistfiles = [
+                    join(directory, f)
+                    for f in listdir(directory)
+                    if isfile(join(directory, f))
+                ]
                 for f in raddistfiles:
                     onlyfiles.append(f)
+
         else:
             # returns all files in RadDist_Saves folder
-            onlyfiles = [join(self.raddist_saves_directory, f) for f in listdir(self.raddist_saves_directory)\
-                         if isfile(join(self.raddist_saves_directory, f))]
-        
+            onlyfiles = [
+                join(self.raddist_saves_directory, f)
+                for f in listdir(self.raddist_saves_directory)
+                if isfile(join(self.raddist_saves_directory, f))
+            ]
+
         for distIndx in range(len(onlyfiles)):
             loadFileName = onlyfiles[distIndx]
-            radDist = self.load_single_raddist(LoadFileName = loadFileName)
-            
+            radDist = self.load_single_raddist(LoadFileName=loadFileName)
+
             self.allRadDistsVec.append(radDist)
-            
-    def calc_pvals(self, RadDistVec, BoloExpData, PowerUpperBound = 6000.0):
-        
+
+    def calc_pvals(self, RadDistVec, BoloExpData, PowerUpperBound=6000.0):
+
         print("Calculating P-Values")
-        
+
         numChannels = np.sum([len(x) for x in BoloExpData])
-        
-        bolo_exp = self.rearrange_powers_array(Powers = BoloExpData)
-        
+
+        bolo_exp = self.rearrange_powers_array(Powers=BoloExpData)
+
         chisqlist = []
         pValList = []
         fitsBoloFirsts = []
         fitsBoloSeconds = []
         preScales = []
         channel_errs = []
-        
+
         # this is for different errors at each toroidal location
         for i in range(self.numTorLocs):
             expMax = np.max(bolo_exp[i])
             channel_errs.append(np.array([0.1 * expMax] * len(bolo_exp[i])))
-            
+
         for radDist in RadDistVec:
-            synth_powers_p1 = self.rearrange_powers_array(Powers=copy(radDist.boloCameras_powers))
-            synth_powers_p2 = self.rearrange_powers_array(Powers=copy(radDist.boloCameras_powers_2nd))
-            
+            synth_powers_p1 = self.rearrange_powers_array(
+                Powers=copy(radDist.boloCameras_powers)
+            )
+            synth_powers_p2 = self.rearrange_powers_array(
+                Powers=copy(radDist.boloCameras_powers_2nd)
+            )
+
             # removes any negative numbers from experimental data for prescaling.
             # negative channels should really be removed in fitting also; on JET, channel 16
             # removed in fitting function
@@ -110,56 +124,78 @@ class Emis3D(object):
                 for indx2 in range(len(bolo_exp_for_sum[indx1])):
                     if bolo_exp_for_sum[indx1][indx2] < 0:
                         bolo_exp_for_sum[indx1][indx2] = 0
-            
+
             # uniformly pre-scales synthetic powers to same order of magnitude as experimental
             # data, to put in range of fitting algorithm
-            preScaleFactorNum = np.sum([np.sum(bolo_exp[indx]) for indx in range(len(bolo_exp))])
-            preScaleFactorDenom = np.sum([np.sum(synth_powers_p1[indx]) for indx in range(len(synth_powers_p1))])
+            preScaleFactorNum = np.sum(
+                [np.sum(bolo_exp[indx]) for indx in range(len(bolo_exp))]
+            )
+            preScaleFactorDenom = np.sum(
+                [np.sum(synth_powers_p1[indx]) for indx in range(len(synth_powers_p1))]
+            )
             preScaleFactor = preScaleFactorNum / preScaleFactorDenom
-                
+
             for i in range(self.numTorLocs):
                 synth_powers_p1[i] = np.array(synth_powers_p1[i]) * preScaleFactor
-                if len(synth_powers_p2) > 0: # check if there's a second puncture
+                if len(synth_powers_p2) > 0:  # check if there's a second puncture
                     synth_powers_p2[i] = np.array(synth_powers_p2[i]) * preScaleFactor
-            
-            p0Firsts, p0Seconds, boundsFirsts, boundsSeconds, fittingFunc =\
-                self.fitting_func_setup(Bolo_exp=bolo_exp, Synth_powers_p1=synth_powers_p1,\
-                    Synth_powers_p2=synth_powers_p2, Channel_errs=channel_errs, PowerUpperBound=PowerUpperBound)
 
-            res = minimize(fittingFunc, p0Firsts + p0Seconds, bounds=boundsFirsts+boundsSeconds)
+            p0Firsts, p0Seconds, boundsFirsts, boundsSeconds, fittingFunc = (
+                self.fitting_func_setup(
+                    Bolo_exp=bolo_exp,
+                    Synth_powers_p1=synth_powers_p1,
+                    Synth_powers_p2=synth_powers_p2,
+                    Channel_errs=channel_errs,
+                    PowerUpperBound=PowerUpperBound,
+                )
+            )
+
+            res = minimize(
+                fittingFunc, p0Firsts + p0Seconds, bounds=boundsFirsts + boundsSeconds
+            )
             res.fun
-            fitsBoloFirsts.append(res.x[:self.numTorLocs])
-            fitsBoloSeconds.append(res.x[self.numTorLocs:])
+            fitsBoloFirsts.append(res.x[: self.numTorLocs])
+            fitsBoloSeconds.append(res.x[self.numTorLocs :])
             preScales.append(preScaleFactor)
-            
+
             if radDist.distType == "Helical":
                 degree_of_freedom = numChannels - (len(p0Firsts) + len(p0Seconds) + 1)
             else:
                 degree_of_freedom = numChannels - (len(p0Firsts) + 1)
-            chisq = (res.fun)/degree_of_freedom
+            chisq = (res.fun) / degree_of_freedom
             chisqlist.append(chisq)
             pValList.append(RedChi2_To_Pvalue(chisq, degree_of_freedom))
-        
-        return chisqlist, pValList, fitsBoloFirsts, fitsBoloSeconds, channel_errs, preScales
-    
-    def calc_pvals_segmented(self, RadDistVec, BoloExpData, PowerUpperBound = 6000.0):
+
+        return (
+            chisqlist,
+            pValList,
+            fitsBoloFirsts,
+            fitsBoloSeconds,
+            channel_errs,
+            preScales,
+        )
+
+    def calc_pvals_segmented(self, RadDistVec, BoloExpData, PowerUpperBound=6000.0):
         # only set up for SPARC, and the July 2023 Bolo configuration
-                
+
         print("Calculating P-Values")
-        numChannels = self.tokamakAMode.numTorLocs\
-            * self.tokamakAMode.cameras_per_tor * self.tokamakAMode.channelsPerCamera
+        numChannels = (
+            self.tokamakAMode.numTorLocs
+            * self.tokamakAMode.cameras_per_tor
+            * self.tokamakAMode.channelsPerCamera
+        )
 
         exp_powers_unsegmented = copy(BoloExpData)
         maxExpPower = np.max(exp_powers_unsegmented)
-        minPowerCutoff = 0.0#0.01*maxExpPower
-        
+        minPowerCutoff = 0.0  # 0.01*maxExpPower
+
         chisqlist = []
         pValList = []
         fitsBoloFirsts = []
         fitsBoloSeconds = []
         preScales = []
         channel_errs = []
-        
+
         for radDist in RadDistVec:
             if radDist.distType == "Helical" or radDist.distType == "ElongatedHelical":
 
@@ -168,17 +204,38 @@ class Emis3D(object):
                 synth_powers_segmented_2nd = copy(radDist.bolo_powers_segmented_2nd)
                 num_segments = len(synth_powers_segmented[0][0])
 
-                #Creates an array of angles which correspond to the center of each segment.
+                # Creates an array of angles which correspond to the center of each segment.
                 # first half are positive, second half are negative: goes from 0 to pi then
                 # -pi to 0. To match how the powers array indexing works. Then goes around a
                 # second time for second punctures.
-                halfSegmentPhiWidth = np.pi/num_segments
-                half_num_segments = int(num_segments/2)
-                segmentCenterPhis1 = np.linspace(halfSegmentPhiWidth, np.pi - halfSegmentPhiWidth, half_num_segments)
-                segmentCenterPhis2 = np.linspace(-np.pi + halfSegmentPhiWidth, -halfSegmentPhiWidth, half_num_segments)
-                segmentCenterPhis3 = np.linspace(-(2.0*np.pi) + halfSegmentPhiWidth, -np.pi -halfSegmentPhiWidth, half_num_segments)
-                segmentCenterPhis4 = np.linspace(np.pi + halfSegmentPhiWidth, (2.0*np.pi) - halfSegmentPhiWidth, half_num_segments)
-                segmentCenterPhis = np.concatenate((segmentCenterPhis1, segmentCenterPhis2, segmentCenterPhis3, segmentCenterPhis4))
+                halfSegmentPhiWidth = np.pi / num_segments
+                half_num_segments = int(num_segments / 2)
+                segmentCenterPhis1 = np.linspace(
+                    halfSegmentPhiWidth, np.pi - halfSegmentPhiWidth, half_num_segments
+                )
+                segmentCenterPhis2 = np.linspace(
+                    -np.pi + halfSegmentPhiWidth,
+                    -halfSegmentPhiWidth,
+                    half_num_segments,
+                )
+                segmentCenterPhis3 = np.linspace(
+                    -(2.0 * np.pi) + halfSegmentPhiWidth,
+                    -np.pi - halfSegmentPhiWidth,
+                    half_num_segments,
+                )
+                segmentCenterPhis4 = np.linspace(
+                    np.pi + halfSegmentPhiWidth,
+                    (2.0 * np.pi) - halfSegmentPhiWidth,
+                    half_num_segments,
+                )
+                segmentCenterPhis = np.concatenate(
+                    (
+                        segmentCenterPhis1,
+                        segmentCenterPhis2,
+                        segmentCenterPhis3,
+                        segmentCenterPhis4,
+                    )
+                )
 
                 # uniformly pre-scales synthetic powers to same order of magnitude as experimental
                 # data, to put in range of fitting algorithm
@@ -192,28 +249,44 @@ class Emis3D(object):
                 # currently, no channels are ignored
                 for CameraIndx in range(len(exp_powers_unsegmented)):
                     for channelIndx in range(len(exp_powers_unsegmented[CameraIndx])):
-                        channelExpPower = exp_powers_unsegmented[CameraIndx][channelIndx] 
+                        channelExpPower = exp_powers_unsegmented[CameraIndx][
+                            channelIndx
+                        ]
                         if channelExpPower <= minPowerCutoff:
-                            numIgnoredChannels +=1
-                        for channelSegmentIndx in range(len(synth_powers_segmented[CameraIndx][channelIndx])):
-                            segmentSynthPower = synth_powers_segmented[CameraIndx][channelIndx][channelSegmentIndx]
-                            synth_powers_segmented[CameraIndx][channelIndx][channelSegmentIndx] = segmentSynthPower * preScaleFactor           
-                
-                p0Firsts, p0Seconds, boundsFirsts, boundsSeconds, fittingFunc =\
-                    self.fitting_func_setup_segmented_helical(\
-                    Bolo_exp_unsegmented=exp_powers_unsegmented, Synth_powers_segmented=synth_powers_segmented,\
-                    PowerUpperBound=PowerUpperBound, MinPowerCutoff = minPowerCutoff,\
-                    SegmentCenterPhis = segmentCenterPhis, MaxExpPower = maxExpPower, NumPuncs=2,\
-                    Synth_powers_segmented_2nd = synth_powers_segmented_2nd)
-                
+                            numIgnoredChannels += 1
+                        for channelSegmentIndx in range(
+                            len(synth_powers_segmented[CameraIndx][channelIndx])
+                        ):
+                            segmentSynthPower = synth_powers_segmented[CameraIndx][
+                                channelIndx
+                            ][channelSegmentIndx]
+                            synth_powers_segmented[CameraIndx][channelIndx][
+                                channelSegmentIndx
+                            ] = (segmentSynthPower * preScaleFactor)
+
+                p0Firsts, p0Seconds, boundsFirsts, boundsSeconds, fittingFunc = (
+                    self.fitting_func_setup_segmented_helical(
+                        Bolo_exp_unsegmented=exp_powers_unsegmented,
+                        Synth_powers_segmented=synth_powers_segmented,
+                        PowerUpperBound=PowerUpperBound,
+                        MinPowerCutoff=minPowerCutoff,
+                        SegmentCenterPhis=segmentCenterPhis,
+                        MaxExpPower=maxExpPower,
+                        NumPuncs=2,
+                        Synth_powers_segmented_2nd=synth_powers_segmented_2nd,
+                    )
+                )
+
                 res = minimize(fittingFunc, p0Firsts, bounds=boundsFirsts)
                 res.fun
-                fitsBoloFirsts.append(res.x[:self.numTorLocs])
-                fitsBoloSeconds.append(res.x[self.numTorLocs:])
+                fitsBoloFirsts.append(res.x[: self.numTorLocs])
+                fitsBoloSeconds.append(res.x[self.numTorLocs :])
                 preScales.append(preScaleFactor)
-                
-                degree_of_freedom = numChannels - (len(p0Firsts) + 1) - numIgnoredChannels
-                chisq = (res.fun)/degree_of_freedom
+
+                degree_of_freedom = (
+                    numChannels - (len(p0Firsts) + 1) - numIgnoredChannels
+                )
+                chisq = (res.fun) / degree_of_freedom
                 chisqlist.append(chisq)
                 pValList.append(RedChi2_To_Pvalue(chisq, degree_of_freedom))
 
@@ -222,21 +295,25 @@ class Emis3D(object):
                 synth_powers_segmented = copy(radDist.bolo_powers_segmented)
                 num_segments = len(synth_powers_segmented[0][0])
 
-                #Creates an array of angles which correspond to the center of each segment.
+                # Creates an array of angles which correspond to the center of each segment.
                 # first half are positive, second half are negative: goes from 0 to pi then
                 # -pi to 0. To match how the powers array indexing works
-                halfSegmentPhiWidth = np.pi/num_segments
-                segmentCenterPhis = np.linspace(halfSegmentPhiWidth, (2.0*np.pi) - halfSegmentPhiWidth, num_segments)
+                halfSegmentPhiWidth = np.pi / num_segments
+                segmentCenterPhis = np.linspace(
+                    halfSegmentPhiWidth,
+                    (2.0 * np.pi) - halfSegmentPhiWidth,
+                    num_segments,
+                )
                 for phiIndx in range(len(segmentCenterPhis)):
                     if segmentCenterPhis[phiIndx] > np.pi:
-                        segmentCenterPhis[phiIndx] += - 2*np.pi
+                        segmentCenterPhis[phiIndx] += -2 * np.pi
 
                 # uniformly pre-scales synthetic powers to same order of magnitude as experimental
                 # data, to put in range of fitting algorithm
                 preScaleFactorNum = np.sum(exp_powers_unsegmented)
                 preScaleFactorDenom = np.sum(synth_powers_unsegmented)
                 preScaleFactor = preScaleFactorNum / preScaleFactorDenom
-                #print("Pre Scale Factor = " + str(preScaleFactor))
+                # print("Pre Scale Factor = " + str(preScaleFactor))
 
                 numIgnoredChannels = 0
                 # this loop for counting the number of ignored channels for the purposes of the degree of freedom
@@ -244,67 +321,113 @@ class Emis3D(object):
                 # currently, no channels are ignored
                 for CameraIndx in range(len(exp_powers_unsegmented)):
                     for channelIndx in range(len(exp_powers_unsegmented[CameraIndx])):
-                        channelExpPower = exp_powers_unsegmented[CameraIndx][channelIndx] 
+                        channelExpPower = exp_powers_unsegmented[CameraIndx][
+                            channelIndx
+                        ]
                         if channelExpPower <= minPowerCutoff:
-                            numIgnoredChannels +=1
-                        for channelSegmentIndx in range(len(synth_powers_segmented[CameraIndx][channelIndx])):
-                            segmentSynthPower = synth_powers_segmented[CameraIndx][channelIndx][channelSegmentIndx]
-                            synth_powers_segmented[CameraIndx][channelIndx][channelSegmentIndx] = segmentSynthPower * preScaleFactor           
-                
+                            numIgnoredChannels += 1
+                        for channelSegmentIndx in range(
+                            len(synth_powers_segmented[CameraIndx][channelIndx])
+                        ):
+                            segmentSynthPower = synth_powers_segmented[CameraIndx][
+                                channelIndx
+                            ][channelSegmentIndx]
+                            synth_powers_segmented[CameraIndx][channelIndx][
+                                channelSegmentIndx
+                            ] = (segmentSynthPower * preScaleFactor)
+
                 if radDist.distType in ["ReflectedToroidal", "TiltedReflectedToroidal"]:
-                    p0Firsts, p0Seconds, boundsFirsts, boundsSeconds, fittingFunc =\
-                        self.fitting_func_setup_segmented_reflectedtor(\
-                        Bolo_exp_unsegmented=exp_powers_unsegmented, Synth_powers_segmented=synth_powers_segmented,\
-                        PowerUpperBound=PowerUpperBound, MinPowerCutoff = minPowerCutoff,\
-                        SegmentCenterPhis = segmentCenterPhis, MaxExpPower = maxExpPower)
+                    p0Firsts, p0Seconds, boundsFirsts, boundsSeconds, fittingFunc = (
+                        self.fitting_func_setup_segmented_reflectedtor(
+                            Bolo_exp_unsegmented=exp_powers_unsegmented,
+                            Synth_powers_segmented=synth_powers_segmented,
+                            PowerUpperBound=PowerUpperBound,
+                            MinPowerCutoff=minPowerCutoff,
+                            SegmentCenterPhis=segmentCenterPhis,
+                            MaxExpPower=maxExpPower,
+                        )
+                    )
                 elif radDist.distType in ["ElongatedRing"]:
-                    p0Firsts, p0Seconds, boundsFirsts, boundsSeconds, fittingFunc =\
-                        self.fitting_func_setup_segmented_ering(\
-                        Bolo_exp_unsegmented=exp_powers_unsegmented, Synth_powers_segmented=synth_powers_segmented,\
-                        PowerUpperBound=PowerUpperBound, MinPowerCutoff = minPowerCutoff,\
-                        SegmentCenterPhis = segmentCenterPhis, MaxExpPower = maxExpPower)
+                    p0Firsts, p0Seconds, boundsFirsts, boundsSeconds, fittingFunc = (
+                        self.fitting_func_setup_segmented_ering(
+                            Bolo_exp_unsegmented=exp_powers_unsegmented,
+                            Synth_powers_segmented=synth_powers_segmented,
+                            PowerUpperBound=PowerUpperBound,
+                            MinPowerCutoff=minPowerCutoff,
+                            SegmentCenterPhis=segmentCenterPhis,
+                            MaxExpPower=maxExpPower,
+                        )
+                    )
                 else:
-                    p0Firsts, p0Seconds, boundsFirsts, boundsSeconds, fittingFunc =\
-                        self.fitting_func_setup_segmented(\
-                        Bolo_exp_unsegmented=exp_powers_unsegmented, Synth_powers_segmented=synth_powers_segmented,\
-                        PowerUpperBound=PowerUpperBound, MinPowerCutoff = minPowerCutoff,\
-                        SegmentCenterPhis = segmentCenterPhis, MaxExpPower = maxExpPower)
-                
-                res = minimize(fittingFunc, p0Firsts, bounds=boundsFirsts) # second punctures not yet involved
+                    p0Firsts, p0Seconds, boundsFirsts, boundsSeconds, fittingFunc = (
+                        self.fitting_func_setup_segmented(
+                            Bolo_exp_unsegmented=exp_powers_unsegmented,
+                            Synth_powers_segmented=synth_powers_segmented,
+                            PowerUpperBound=PowerUpperBound,
+                            MinPowerCutoff=minPowerCutoff,
+                            SegmentCenterPhis=segmentCenterPhis,
+                            MaxExpPower=maxExpPower,
+                        )
+                    )
+
+                res = minimize(
+                    fittingFunc, p0Firsts, bounds=boundsFirsts
+                )  # second punctures not yet involved
                 res.fun
-                fitsBoloFirsts.append(res.x[:self.numTorLocs])
-                fitsBoloSeconds.append(res.x[self.numTorLocs:])
+                fitsBoloFirsts.append(res.x[: self.numTorLocs])
+                fitsBoloSeconds.append(res.x[self.numTorLocs :])
                 preScales.append(preScaleFactor)
-                
-                degree_of_freedom = numChannels - (len(p0Firsts) + 1) - numIgnoredChannels
-                chisq = (res.fun)/degree_of_freedom
+
+                degree_of_freedom = (
+                    numChannels - (len(p0Firsts) + 1) - numIgnoredChannels
+                )
+                chisq = (res.fun) / degree_of_freedom
                 chisqlist.append(chisq)
                 pValList.append(RedChi2_To_Pvalue(chisq, degree_of_freedom))
-        
-        return chisqlist, pValList, fitsBoloFirsts, fitsBoloSeconds, channel_errs, preScales
-            
-    def calc_fits(self, Etime, ErrorPool = False, PvalCutoff = None):
+
+        return (
+            chisqlist,
+            pValList,
+            fitsBoloFirsts,
+            fitsBoloSeconds,
+            channel_errs,
+            preScales,
+        )
+
+    def calc_fits(self, Etime, ErrorPool=False, PvalCutoff=None):
         # calculates reduced chi^2 values for radiation structure library for one timestep
 
         if len(self.allRadDistsVec) == 0:
-            self.load_raddists(TokamakName = self.tokamakAMode.tokamakName)
+            self.load_raddists(TokamakName=self.tokamakAMode.tokamakName)
 
         if self.comparingTo == "Experiment":
-            boloExpData = self.load_bolo_exp_timestep(EvalTime = Etime)
+            boloExpData = self.load_bolo_exp_timestep(EvalTime=Etime)
         elif self.comparingTo == "Simulation":
             boloExpData = self.load_radDist_as_exp()[Etime]
-        
+
         if self.torSegmented:
-            self.chisqVec, self.pvalVec, self.fitsBoloFirsts, self.fitsBoloSeconds,\
-                self.channel_errs, self.preScaleVec =\
-                self.calc_pvals_segmented(self.allRadDistsVec, BoloExpData = boloExpData)
+            (
+                self.chisqVec,
+                self.pvalVec,
+                self.fitsBoloFirsts,
+                self.fitsBoloSeconds,
+                self.channel_errs,
+                self.preScaleVec,
+            ) = self.calc_pvals_segmented(self.allRadDistsVec, BoloExpData=boloExpData)
         else:
-            self.chisqVec, self.pvalVec, self.fitsBoloFirsts, self.fitsBoloSeconds,\
-                self.channel_errs, self.preScaleVec =\
-                self.calc_pvals(self.allRadDistsVec, BoloExpData = boloExpData)
-        
+            (
+                self.chisqVec,
+                self.pvalVec,
+                self.fitsBoloFirsts,
+                self.fitsBoloSeconds,
+                self.channel_errs,
+                self.preScaleVec,
+            ) = self.calc_pvals(self.allRadDistsVec, BoloExpData=boloExpData)
+
         # take minimum pval RadDist, which is the closest fit
-        if min(self.pvalVec) == 1.0: # covers case where Pvals bottom out (no pval better than 3). Not Ideal.
+        if (
+            min(self.pvalVec) == 1.0
+        ):  # covers case where Pvals bottom out (no pval better than 3). Not Ideal.
             self.minInd = np.argmin(self.chisqVec)
         else:
             self.minInd = np.argmin(self.pvalVec)
@@ -317,15 +440,20 @@ class Emis3D(object):
         self.minpval = self.pvalVec[self.minInd]
         self.minRadDist = self.allRadDistsVec[self.minInd]
         if self.torSegmented:
-            print("best fit radDist at this timestep is toroidal z=" + str(self.minRadDist.startZ)\
-                + ", r=" + str(self.minRadDist.startR)\
-                + ", polsigma=" + str(self.minRadDist.polSigma))
-        
+            print(
+                "best fit radDist at this timestep is toroidal z="
+                + str(self.minRadDist.startZ)
+                + ", r="
+                + str(self.minRadDist.startR)
+                + ", polsigma="
+                + str(self.minRadDist.polSigma)
+            )
+
         if ErrorPool:
-            self.errorDists=[]
-            self.errorFitsFirsts=[]
-            self.errorFitsSeconds=[]
-            self.errorPrescales=[]
+            self.errorDists = []
+            self.errorFitsFirsts = []
+            self.errorFitsSeconds = []
+            self.errorPrescales = []
             poolsize = 0
             for distNum in range(len(self.allRadDistsVec)):
                 if self.pvalVec[distNum] <= PvalCutoff:
@@ -334,59 +462,94 @@ class Emis3D(object):
                     self.errorFitsFirsts.append(self.fitsBoloFirsts[distNum])
                     self.errorFitsSeconds.append(self.fitsBoloSeconds[distNum])
                     self.errorPrescales.append(self.preScaleVec[distNum])
-            
-            if not self.errorDists: # covers case where even best fit radDist is not within Pval cutoff.
+
+            if (
+                not self.errorDists
+            ):  # covers case where even best fit radDist is not within Pval cutoff.
                 # Adds just best fit to error pool
                 self.errorDists.append(self.minRadDist)
                 self.errorFitsFirsts.append(self.bestFitsBoloFirsts)
                 self.errorFitsSeconds.append(self.bestFitsBoloSeconds)
                 self.errorPrescales.append(self.minPreScale)
             print(" pool size is " + str(poolsize))
-            
+
     def gaussian(self, Phi, Sigma, Mu, Amplitude, OffsetVert):
-            coeff = 1.0 / (Sigma * math.sqrt(2.0 * math.pi))
-            exponential = np.exp(-((Phi - Mu) / Sigma)**2 / 2.0)
-            return (Amplitude * coeff * exponential) + OffsetVert
-    
+        coeff = 1.0 / (Sigma * math.sqrt(2.0 * math.pi))
+        exponential = np.exp(-(((Phi - Mu) / Sigma) ** 2) / 2.0)
+        return (Amplitude * coeff * exponential) + OffsetVert
+
     def gaussian_no_coeff(self, Phi, Sigma, Mu, Amplitude, OffsetVert):
-            coeff = 1.0 / (Sigma * math.sqrt(2.0 * math.pi))
-            return self.gaussian(Phi=Phi, Sigma=Sigma, Mu=Mu,
-                                 Amplitude=Amplitude, OffsetVert=OffsetVert) / coeff
-    
+        coeff = 1.0 / (Sigma * math.sqrt(2.0 * math.pi))
+        return (
+            self.gaussian(
+                Phi=Phi, Sigma=Sigma, Mu=Mu, Amplitude=Amplitude, OffsetVert=OffsetVert
+            )
+            / coeff
+        )
+
     def asymmetric_gaussian_arr(self, Phi, SigmaLeft, SigmaRight, Amplitude, Mu=None):
         # Returns an asymmetric gaussian. Implemented to handle arrays, since the curve_fit
         # function seems to need that
 
         if hasattr(Mu, "__len__"):
-            mu=Mu
-        elif Mu==None:
+            mu = Mu
+        elif Mu == None:
             mu = self.tokamakAMode.injectionPhiTor
         else:
-            mu=Mu
-        
-        if hasattr(Phi, "__len__"): # check if Phi is array-like
+            mu = Mu
+
+        if hasattr(Phi, "__len__"):  # check if Phi is array-like
             yval = []
-            #for i in range(len(Phi)):
+            # for i in range(len(Phi)):
             for phi in Phi:
-                #phi = Phi[i]
+                # phi = Phi[i]
                 if phi < mu:
-                    yval.append(self.gaussian_no_coeff(Phi=phi, Sigma=SigmaLeft, Mu=mu,\
-                            Amplitude=Amplitude, OffsetVert=0.0))
+                    yval.append(
+                        self.gaussian_no_coeff(
+                            Phi=phi,
+                            Sigma=SigmaLeft,
+                            Mu=mu,
+                            Amplitude=Amplitude,
+                            OffsetVert=0.0,
+                        )
+                    )
                 else:
-                    yval.append(self.gaussian_no_coeff(Phi=phi, Sigma=SigmaRight, Mu=mu,\
-                            Amplitude=Amplitude, OffsetVert=0.0))
+                    yval.append(
+                        self.gaussian_no_coeff(
+                            Phi=phi,
+                            Sigma=SigmaRight,
+                            Mu=mu,
+                            Amplitude=Amplitude,
+                            OffsetVert=0.0,
+                        )
+                    )
         else:
             if Phi < mu:
-                yval=self.gaussian_no_coeff(Phi=Phi, Sigma=SigmaLeft, Mu=mu,\
-                        Amplitude=Amplitude, OffsetVert=0.0)
+                yval = self.gaussian_no_coeff(
+                    Phi=Phi, Sigma=SigmaLeft, Mu=mu, Amplitude=Amplitude, OffsetVert=0.0
+                )
             else:
-                yval=self.gaussian_no_coeff(Phi=Phi, Sigma=SigmaRight, Mu=mu,\
-                        Amplitude=Amplitude, OffsetVert=0.0)   
-        
+                yval = self.gaussian_no_coeff(
+                    Phi=Phi,
+                    Sigma=SigmaRight,
+                    Mu=mu,
+                    Amplitude=Amplitude,
+                    OffsetVert=0.0,
+                )
+
         return yval
 
-    def asymmetric_gaussian_extrapeaked_arr(self, Phi, SigmaLeft, SigmaRight, Amplitude, Mu=None,
-        extrapeakMult = 1, extrapeakWidth=(2.0*math.pi/8.0), HArrayPhi=(5.0*math.pi/4.0)):
+    def asymmetric_gaussian_extrapeaked_arr(
+        self,
+        Phi,
+        SigmaLeft,
+        SigmaRight,
+        Amplitude,
+        Mu=None,
+        extrapeakMult=1,
+        extrapeakWidth=(2.0 * math.pi / 8.0),
+        HArrayPhi=(5.0 * math.pi / 4.0),
+    ):
         # Returns an asymmetric gaussian. Implemented to handle arrays, since the curve_fit
         # function seems to need that
         # has extra peaking of extrapeakMult within extrapeakWidth of injector location
@@ -394,340 +557,537 @@ class Emis3D(object):
         injectorPhi = self.tokamakAMode.injectionPhiTor
 
         if hasattr(Mu, "__len__"):
-            mu=Mu
-        elif Mu==None:
+            mu = Mu
+        elif Mu == None:
             mu = self.tokamakAMode.injectionPhiTor
         else:
-            mu=Mu
-        
+            mu = Mu
+
         if self.extrapeaked_variation == 1:
-            if hasattr(Phi, "__len__"): # check if Phi is array-like
+            if hasattr(Phi, "__len__"):  # check if Phi is array-like
                 yval = []
-                #for i in range(len(Phi)):
+                # for i in range(len(Phi)):
                 for phi in Phi:
-                    #phi = Phi[i]
+                    # phi = Phi[i]
                     if phi < mu:
-                        newyval = self.gaussian_no_coeff(Phi=phi, Sigma=SigmaLeft, Mu=mu,\
-                                Amplitude=Amplitude, OffsetVert=0.0)
+                        newyval = self.gaussian_no_coeff(
+                            Phi=phi,
+                            Sigma=SigmaLeft,
+                            Mu=mu,
+                            Amplitude=Amplitude,
+                            OffsetVert=0.0,
+                        )
                         if abs(phi - injectorPhi) <= extrapeakWidth:
-                            newyval = newyval*extrapeakMult
+                            newyval = newyval * extrapeakMult
                         yval.append(newyval)
                     else:
-                        newyval = self.gaussian_no_coeff(Phi=phi, Sigma=SigmaRight, Mu=mu,\
-                                Amplitude=Amplitude, OffsetVert=0.0)
+                        newyval = self.gaussian_no_coeff(
+                            Phi=phi,
+                            Sigma=SigmaRight,
+                            Mu=mu,
+                            Amplitude=Amplitude,
+                            OffsetVert=0.0,
+                        )
                         if abs(phi - injectorPhi) <= extrapeakWidth:
-                            newyval = newyval*extrapeakMult
+                            newyval = newyval * extrapeakMult
                         yval.append(newyval)
             else:
                 if Phi < mu:
-                    yval=self.gaussian_no_coeff(Phi=Phi, Sigma=SigmaLeft, Mu=mu,\
-                            Amplitude=Amplitude, OffsetVert=0.0)
+                    yval = self.gaussian_no_coeff(
+                        Phi=Phi,
+                        Sigma=SigmaLeft,
+                        Mu=mu,
+                        Amplitude=Amplitude,
+                        OffsetVert=0.0,
+                    )
                 else:
-                    yval=self.gaussian_no_coeff(Phi=Phi, Sigma=SigmaRight, Mu=mu,\
-                            Amplitude=Amplitude, OffsetVert=0.0)
+                    yval = self.gaussian_no_coeff(
+                        Phi=Phi,
+                        Sigma=SigmaRight,
+                        Mu=mu,
+                        Amplitude=Amplitude,
+                        OffsetVert=0.0,
+                    )
                 if abs(Phi - injectorPhi) <= extrapeakWidth:
-                            yval = yval*extrapeakMult
+                    yval = yval * extrapeakMult
         elif self.extrapeaked_variation == 2:
-            if hasattr(Phi, "__len__"): # check if Phi is array-like
+            if hasattr(Phi, "__len__"):  # check if Phi is array-like
                 yval = []
-                #for i in range(len(Phi)):
+                # for i in range(len(Phi)):
                 for phi in Phi:
                     if abs(phi - injectorPhi) <= extrapeakWidth:
-                        hArrayVal1 = self.gaussian_no_coeff(Phi=HArrayPhi, Sigma=SigmaRight, Mu=mu,\
-                                    Amplitude=Amplitude, OffsetVert=0.0)
-                        hArrayVal2 = self.gaussian_no_coeff(Phi=(HArrayPhi-(2.0*math.pi)), Sigma=SigmaLeft, Mu=mu,\
-                                    Amplitude=Amplitude, OffsetVert=0.0)
+                        hArrayVal1 = self.gaussian_no_coeff(
+                            Phi=HArrayPhi,
+                            Sigma=SigmaRight,
+                            Mu=mu,
+                            Amplitude=Amplitude,
+                            OffsetVert=0.0,
+                        )
+                        hArrayVal2 = self.gaussian_no_coeff(
+                            Phi=(HArrayPhi - (2.0 * math.pi)),
+                            Sigma=SigmaLeft,
+                            Mu=mu,
+                            Amplitude=Amplitude,
+                            OffsetVert=0.0,
+                        )
                         newyval = (hArrayVal1 + hArrayVal2) * self.extrapeakedMult
                         yval.append(newyval)
                     else:
                         if phi < mu:
-                            newyval = self.gaussian_no_coeff(Phi=phi, Sigma=SigmaLeft, Mu=mu,\
-                                    Amplitude=Amplitude, OffsetVert=0.0)
+                            newyval = self.gaussian_no_coeff(
+                                Phi=phi,
+                                Sigma=SigmaLeft,
+                                Mu=mu,
+                                Amplitude=Amplitude,
+                                OffsetVert=0.0,
+                            )
                             yval.append(newyval)
                         else:
-                            newyval = self.gaussian_no_coeff(Phi=phi, Sigma=SigmaRight, Mu=mu,\
-                                    Amplitude=Amplitude, OffsetVert=0.0)
+                            newyval = self.gaussian_no_coeff(
+                                Phi=phi,
+                                Sigma=SigmaRight,
+                                Mu=mu,
+                                Amplitude=Amplitude,
+                                OffsetVert=0.0,
+                            )
                             yval.append(newyval)
             else:
                 if abs(Phi - injectorPhi) <= extrapeakWidth:
-                    hArrayVal1 = self.gaussian_no_coeff(Phi=HArrayPhi, Sigma=SigmaRight, Mu=mu,\
-                                    Amplitude=Amplitude, OffsetVert=0.0)
-                    hArrayVal2 = self.gaussian_no_coeff(Phi=(HArrayPhi-(2.0*math.pi)), Sigma=SigmaLeft, Mu=mu,\
-                                Amplitude=Amplitude, OffsetVert=0.0)
+                    hArrayVal1 = self.gaussian_no_coeff(
+                        Phi=HArrayPhi,
+                        Sigma=SigmaRight,
+                        Mu=mu,
+                        Amplitude=Amplitude,
+                        OffsetVert=0.0,
+                    )
+                    hArrayVal2 = self.gaussian_no_coeff(
+                        Phi=(HArrayPhi - (2.0 * math.pi)),
+                        Sigma=SigmaLeft,
+                        Mu=mu,
+                        Amplitude=Amplitude,
+                        OffsetVert=0.0,
+                    )
                     yval = (hArrayVal1 + hArrayVal2) * self.extrapeakedMult
                 else:
                     if Phi < mu:
-                        yval=self.gaussian_no_coeff(Phi=Phi, Sigma=SigmaLeft, Mu=mu,\
-                                Amplitude=Amplitude, OffsetVert=0.0)
+                        yval = self.gaussian_no_coeff(
+                            Phi=Phi,
+                            Sigma=SigmaLeft,
+                            Mu=mu,
+                            Amplitude=Amplitude,
+                            OffsetVert=0.0,
+                        )
                     else:
-                        yval=self.gaussian_no_coeff(Phi=Phi, Sigma=SigmaRight, Mu=mu,\
-                                Amplitude=Amplitude, OffsetVert=0.0)
+                        yval = self.gaussian_no_coeff(
+                            Phi=Phi,
+                            Sigma=SigmaRight,
+                            Mu=mu,
+                            Amplitude=Amplitude,
+                            OffsetVert=0.0,
+                        )
 
         return yval
 
-    def cosine_tordist_1pi_arr(self, Phi, BaselineAmplitude, CosineAmpFrac, Mu=None):  
+    def cosine_tordist_1pi_arr(self, Phi, BaselineAmplitude, CosineAmpFrac, Mu=None):
         # Returns a cosine distribution from mu-pi to mu+pi. Implemented to handle arrays
 
-        if hasattr(Mu, "__len__"): # check if Mu is array-like
-            mu=Mu
-        elif Mu==None:
+        if hasattr(Mu, "__len__"):  # check if Mu is array-like
+            mu = Mu
+        elif Mu == None:
             mu = self.tokamakAMode.injectionPhiTor
         else:
-            mu=Mu
-        
-        if hasattr(Phi, "__len__"): # check if Phi is array-like
+            mu = Mu
+
+        if hasattr(Phi, "__len__"):  # check if Phi is array-like
             yvals = []
             for phi in Phi:
-                if abs(phi - mu) > math.pi: # make sure cosine goes from mu-pi to mu+pi
+                if abs(phi - mu) > math.pi:  # make sure cosine goes from mu-pi to mu+pi
                     yval = 0.0
             else:
                 yval = BaselineAmplitude * (1 + (CosineAmpFrac * math.cos((phi - mu))))
-            
+
             yvals.append(yval)
         else:
             phi = Phi
-            if abs(phi - mu) > math.pi: # make sure cosine goes from mu-pi to mu+pi
+            if abs(phi - mu) > math.pi:  # make sure cosine goes from mu-pi to mu+pi
                 yvals = 0.0
             else:
                 yvals = BaselineAmplitude * (1 + (CosineAmpFrac * math.cos((phi - mu))))
-        
+
         return yvals
-    
-    def cosine_tordist_2pi_arr(self, Phi, BaselineAmplitude, CosineAmpFrac, Mu=None):  
+
+    def cosine_tordist_2pi_arr(self, Phi, BaselineAmplitude, CosineAmpFrac, Mu=None):
         # Returns a cosine distribution from mu-pi to mu+pi. Implemented to handle arrays
 
-        if hasattr(Mu, "__len__"): # check if Mu is array-like
-            mu=Mu
-        elif Mu==None:
+        if hasattr(Mu, "__len__"):  # check if Mu is array-like
+            mu = Mu
+        elif Mu == None:
             mu = self.tokamakAMode.injectionPhiTor
         else:
-            mu=Mu
-        
-        if hasattr(Phi, "__len__"): # check if Phi is array-like
+            mu = Mu
+
+        if hasattr(Phi, "__len__"):  # check if Phi is array-like
             yvals = []
             for phi in Phi:
-                if abs(phi - mu) > math.pi: # make sure cosine goes from mu-pi to mu+pi
+                if abs(phi - mu) > math.pi:  # make sure cosine goes from mu-pi to mu+pi
                     if (phi - mu) > math.pi:
-                        phi = phi - (2.0*math.pi)
+                        phi = phi - (2.0 * math.pi)
                     else:
-                        phi = phi + (2.0*math.pi)
+                        phi = phi + (2.0 * math.pi)
 
             yval = BaselineAmplitude * (1 + (CosineAmpFrac * math.cos((phi - mu))))
             yvals.append(yval)
         else:
             phi = Phi
-            if abs(phi - mu) > math.pi: # make sure cosine goes from mu-pi to mu+pi
+            if abs(phi - mu) > math.pi:  # make sure cosine goes from mu-pi to mu+pi
                 if (phi - mu) > math.pi:
-                    phi = phi - (2.0*math.pi)
+                    phi = phi - (2.0 * math.pi)
                 else:
-                    phi = phi + (2.0*math.pi)
+                    phi = phi + (2.0 * math.pi)
 
             yvals = BaselineAmplitude * (1 + (CosineAmpFrac * math.cos((phi - mu))))
-        
+
         return yvals
 
-    def triple_asymmetric_gaussian_tordist_arr(self, Phi, SigmaLeft, SigmaRight, Amplitude, Mu=None):
+    def triple_asymmetric_gaussian_tordist_arr(
+        self, Phi, SigmaLeft, SigmaRight, Amplitude, Mu=None
+    ):
         # Returns three asymmetric gaussians spaced by 120 degrees.
         # Used to model the "resonant" 6-injector mitigation case, in conjunction with
         # ReflectedToroidal radiation structures.
         # Implemented to handle arrays, since the curve_fit function seems to need that
 
         if hasattr(Mu, "__len__"):
-            mu=Mu
-        elif Mu==None:
+            mu = Mu
+        elif Mu == None:
             mu = self.tokamakAMode.injectionPhiTor
         else:
-            mu=Mu
-        
-        if hasattr(Phi, "__len__"): # check if Phi is array-like
+            mu = Mu
+
+        if hasattr(Phi, "__len__"):  # check if Phi is array-like
             yval = []
-            
+
             for phi in Phi:
                 # shift phi to between mu - (math.pi/3.0) and mu + (math.pi/3.0)
-                while phi > (mu + (math.pi/3.0)):
-                    phi = phi - (2.0 * math.pi/3.0)
+                while phi > (mu + (math.pi / 3.0)):
+                    phi = phi - (2.0 * math.pi / 3.0)
 
-                while phi < (mu - (math.pi/3.0)):
-                    phi = phi + (2.0 * math.pi/3.0)
+                while phi < (mu - (math.pi / 3.0)):
+                    phi = phi + (2.0 * math.pi / 3.0)
 
                 if phi < mu:
-                    yval.append(self.gaussian_no_coeff(Phi=phi, Sigma=SigmaLeft, Mu=mu,\
-                            Amplitude=Amplitude, OffsetVert=0.0))
+                    yval.append(
+                        self.gaussian_no_coeff(
+                            Phi=phi,
+                            Sigma=SigmaLeft,
+                            Mu=mu,
+                            Amplitude=Amplitude,
+                            OffsetVert=0.0,
+                        )
+                    )
                 else:
-                    yval.append(self.gaussian_no_coeff(Phi=phi, Sigma=SigmaRight, Mu=mu,\
-                            Amplitude=Amplitude, OffsetVert=0.0))
+                    yval.append(
+                        self.gaussian_no_coeff(
+                            Phi=phi,
+                            Sigma=SigmaRight,
+                            Mu=mu,
+                            Amplitude=Amplitude,
+                            OffsetVert=0.0,
+                        )
+                    )
         else:
             phi = Phi
 
             # shift phi to between mu - (math.pi/3.0) and mu + (math.pi/3.0)
-            while phi > (mu + (math.pi/3.0)):
-                phi = phi - (2.0 * math.pi/3.0)
+            while phi > (mu + (math.pi / 3.0)):
+                phi = phi - (2.0 * math.pi / 3.0)
 
-            while phi < (mu - (math.pi/3.0)):
-                phi = phi + (2.0 * math.pi/3.0)
+            while phi < (mu - (math.pi / 3.0)):
+                phi = phi + (2.0 * math.pi / 3.0)
 
             if phi < mu:
-                yval=self.gaussian_no_coeff(Phi=phi, Sigma=SigmaLeft, Mu=mu,\
-                        Amplitude=Amplitude, OffsetVert=0.0)
+                yval = self.gaussian_no_coeff(
+                    Phi=phi, Sigma=SigmaLeft, Mu=mu, Amplitude=Amplitude, OffsetVert=0.0
+                )
             else:
-                yval=self.gaussian_no_coeff(Phi=phi, Sigma=SigmaRight, Mu=mu,\
-                        Amplitude=Amplitude, OffsetVert=0.0)   
-        
+                yval = self.gaussian_no_coeff(
+                    Phi=phi,
+                    Sigma=SigmaRight,
+                    Mu=mu,
+                    Amplitude=Amplitude,
+                    OffsetVert=0.0,
+                )
+
         return yval
 
-    def fit_asym_gaussian(self, PhiCoords = np.array([-2.0, -1.0, 1.0, 2.0]),\
-                               FitYVals = np.array([3.0, 4.0, 3.0, 0.01]),\
-                               ParametersGuess = np.array([1.0, 1.0, 2.2, np.nan]),\
-                               MovePeak = False, PlotFit = False, MaxIters=800,\
-                                JetPaperPlot=False):
+    def fit_asym_gaussian(
+        self,
+        PhiCoords=np.array([-2.0, -1.0, 1.0, 2.0]),
+        FitYVals=np.array([3.0, 4.0, 3.0, 0.01]),
+        ParametersGuess=np.array([1.0, 1.0, 2.2, np.nan]),
+        MovePeak=False,
+        PlotFit=False,
+        MaxIters=800,
+        JetPaperPlot=False,
+    ):
         # for JetPaperPlot: PhiCoords = np.array([-3.0*np.pi/2.0, -3.0*np.pi/4.0, np.pi/2.0, 5.0*np.pi/4.0])
         # for JetPaperPlot: FitYVals = np.array([3.0, 4.0, 1.0, 0.01])
 
         if not MovePeak:
             parametersGuess = ParametersGuess[0:3]
-            parameters = curve_fit(f=self.asymmetric_gaussian_arr, xdata=PhiCoords,\
-                           ydata=FitYVals, p0=parametersGuess,\
-                           bounds = [(0.0, 0.0, 0.0),\
-                                     (np.inf, np.inf, np.inf)], maxfev=MaxIters)[0]
-    
-            sigmaLeft, sigmaRight, amplitude =\
-                parameters[0], parameters[1], parameters[2]
+            parameters = curve_fit(
+                f=self.asymmetric_gaussian_arr,
+                xdata=PhiCoords,
+                ydata=FitYVals,
+                p0=parametersGuess,
+                bounds=[(0.0, 0.0, 0.0), (np.inf, np.inf, np.inf)],
+                maxfev=MaxIters,
+            )[0]
+
+            sigmaLeft, sigmaRight, amplitude = (
+                parameters[0],
+                parameters[1],
+                parameters[2],
+            )
             mu = self.tokamakAMode.injectionPhiTor
         else:
             parametersGuess = ParametersGuess
             if np.isnan(ParametersGuess[3]):
                 parametersGuess[3] = self.tokamakAMode.injectionPhiTor
-            parameters = curve_fit(f=self.asymmetric_gaussian_arr, xdata=PhiCoords,\
-                               ydata=FitYVals, p0=ParametersGuess,\
-                               bounds = [(0.0, 0.0, 0.0, - np.pi),\
-                                         (np.inf, np.inf, np.inf, np.pi)], maxfev=MaxIters)[0]
-    
-            sigmaLeft, sigmaRight, amplitude, mu =\
-                parameters[0], parameters[1], parameters[2], parameters[3]
-        
+            parameters = curve_fit(
+                f=self.asymmetric_gaussian_arr,
+                xdata=PhiCoords,
+                ydata=FitYVals,
+                p0=ParametersGuess,
+                bounds=[(0.0, 0.0, 0.0, -np.pi), (np.inf, np.inf, np.inf, np.pi)],
+                maxfev=MaxIters,
+            )[0]
+
+            sigmaLeft, sigmaRight, amplitude, mu = (
+                parameters[0],
+                parameters[1],
+                parameters[2],
+                parameters[3],
+            )
+
         if PlotFit:
-            plt.figure(figsize=(4.5,3.0))
+            plt.figure(figsize=(4.5, 3.0))
             xvalues = np.linspace(-2.0 * math.pi, 2.0 * math.pi, 100)
-            yvalues = self.asymmetric_gaussian_arr(Phi=xvalues, SigmaLeft = sigmaLeft,\
-                SigmaRight = sigmaRight, Amplitude = amplitude, Mu=mu)
-            xaxisLabel = r'$\phi$ Toroidal [rad]'
+            yvalues = self.asymmetric_gaussian_arr(
+                Phi=xvalues,
+                SigmaLeft=sigmaLeft,
+                SigmaRight=sigmaRight,
+                Amplitude=amplitude,
+                Mu=mu,
+            )
+            xaxisLabel = r"$\phi$ Toroidal [rad]"
             yaxisLabel = "Radiation Structure\nAmplitude"
             plt.xlabel(xaxisLabel)
             plt.ylabel(yaxisLabel)
             if JetPaperPlot:
-                plt.scatter(PhiCoords[2], FitYVals[2], color='dodgerblue', label = "Vert. Array Puncture 1")
-                plt.scatter(PhiCoords[0], FitYVals[0], color='dodgerblue', marker='^', label = "Vert. Array Puncture 2")
-                plt.plot(xvalues, yvalues, color='orange', label = "Asymmetric Gaussian Fit")
-                plt.scatter(PhiCoords[1], FitYVals[1], color='limegreen', label = "Hor. Array Puncture 1")
-                plt.scatter(PhiCoords[3], FitYVals[3], color='limegreen', marker='^', label = "Hor. Array Puncture 2")
-                plt.legend(ncol=2, loc='upper center', bbox_to_anchor=(0.42, -0.3))
+                plt.scatter(
+                    PhiCoords[2],
+                    FitYVals[2],
+                    color="dodgerblue",
+                    label="Vert. Array Puncture 1",
+                )
+                plt.scatter(
+                    PhiCoords[0],
+                    FitYVals[0],
+                    color="dodgerblue",
+                    marker="^",
+                    label="Vert. Array Puncture 2",
+                )
+                plt.plot(
+                    xvalues, yvalues, color="orange", label="Asymmetric Gaussian Fit"
+                )
+                plt.scatter(
+                    PhiCoords[1],
+                    FitYVals[1],
+                    color="limegreen",
+                    label="Hor. Array Puncture 1",
+                )
+                plt.scatter(
+                    PhiCoords[3],
+                    FitYVals[3],
+                    color="limegreen",
+                    marker="^",
+                    label="Hor. Array Puncture 2",
+                )
+                plt.legend(ncol=2, loc="upper center", bbox_to_anchor=(0.42, -0.3))
                 plt.tight_layout()
             else:
-                plt.scatter(PhiCoords, FitYVals, label = "Puncture Values")
-                plt.plot(xvalues, yvalues, color='orange', label = "Asymmetric Gaussian Fit")
+                plt.scatter(PhiCoords, FitYVals, label="Puncture Values")
+                plt.plot(
+                    xvalues, yvalues, color="orange", label="Asymmetric Gaussian Fit"
+                )
                 plt.legend()
             plt.show()
-            
+
         return sigmaLeft, sigmaRight, amplitude, mu
 
-    def fit_asym_gaussian_extrapeaked(self, PhiCoords = np.array([-2.0, -1.0, 1.0, 2.0]),\
-                               FitYVals = np.array([3.0, 4.0, 3.0, 0.01]),\
-                               ParametersGuess = np.array([1.0, 1.0, 2.2, np.nan]),\
-                               MovePeak = False, PlotFit = False, MaxIters=800,\
-                                JetPaperPlot=False):
+    def fit_asym_gaussian_extrapeaked(
+        self,
+        PhiCoords=np.array([-2.0, -1.0, 1.0, 2.0]),
+        FitYVals=np.array([3.0, 4.0, 3.0, 0.01]),
+        ParametersGuess=np.array([1.0, 1.0, 2.2, np.nan]),
+        MovePeak=False,
+        PlotFit=False,
+        MaxIters=800,
+        JetPaperPlot=False,
+    ):
         # for JetPaperPlot: PhiCoords = np.array([-3.0*np.pi/2.0, -3.0*np.pi/4.0, np.pi/2.0, 5.0*np.pi/4.0])
         # for JetPaperPlot: FitYVals = np.array([3.0, 4.0, 1.0, 0.01])
 
         if not MovePeak:
             parametersGuess = ParametersGuess[0:3]
-            parameters = curve_fit(f=self.asymmetric_gaussian_extrapeaked_arr, xdata=PhiCoords,\
-                           ydata=FitYVals, p0=parametersGuess,\
-                           bounds = [(0.0, 0.0, 0.0),\
-                                     (np.inf, np.inf, np.inf)], maxfev=MaxIters)[0]
-    
-            sigmaLeft, sigmaRight, amplitude =\
-                parameters[0], parameters[1], parameters[2]
+            parameters = curve_fit(
+                f=self.asymmetric_gaussian_extrapeaked_arr,
+                xdata=PhiCoords,
+                ydata=FitYVals,
+                p0=parametersGuess,
+                bounds=[(0.0, 0.0, 0.0), (np.inf, np.inf, np.inf)],
+                maxfev=MaxIters,
+            )[0]
+
+            sigmaLeft, sigmaRight, amplitude = (
+                parameters[0],
+                parameters[1],
+                parameters[2],
+            )
             mu = self.tokamakAMode.injectionPhiTor
         else:
             parametersGuess = ParametersGuess
             if np.isnan(ParametersGuess[3]):
                 parametersGuess[3] = self.tokamakAMode.injectionPhiTor
-            parameters = curve_fit(f=self.asymmetric_gaussian_extrapeaked_arr, xdata=PhiCoords,\
-                               ydata=FitYVals, p0=ParametersGuess,\
-                               bounds = [(0.0, 0.0, 0.0, - np.pi),\
-                                         (np.inf, np.inf, np.inf, np.pi)], maxfev=MaxIters)[0]
-    
-            sigmaLeft, sigmaRight, amplitude, mu =\
-                parameters[0], parameters[1], parameters[2], parameters[3]
-        
+            parameters = curve_fit(
+                f=self.asymmetric_gaussian_extrapeaked_arr,
+                xdata=PhiCoords,
+                ydata=FitYVals,
+                p0=ParametersGuess,
+                bounds=[(0.0, 0.0, 0.0, -np.pi), (np.inf, np.inf, np.inf, np.pi)],
+                maxfev=MaxIters,
+            )[0]
+
+            sigmaLeft, sigmaRight, amplitude, mu = (
+                parameters[0],
+                parameters[1],
+                parameters[2],
+                parameters[3],
+            )
+
         if PlotFit:
-            
+
             xvalues = np.linspace(-2.0 * math.pi, 2.0 * math.pi, 100)
-            yvalues = self.asymmetric_gaussian_extrapeaked_arr(Phi=xvalues, SigmaLeft = sigmaLeft,\
-                SigmaRight = sigmaRight, Amplitude = amplitude, Mu=mu)
-            xaxisLabel = r'$\phi$ Toroidal [rad]'
+            yvalues = self.asymmetric_gaussian_extrapeaked_arr(
+                Phi=xvalues,
+                SigmaLeft=sigmaLeft,
+                SigmaRight=sigmaRight,
+                Amplitude=amplitude,
+                Mu=mu,
+            )
+            xaxisLabel = r"$\phi$ Toroidal [rad]"
             yaxisLabel = "Radiation Structure\nAmplitude"
             if JetPaperPlot:
-                plt.figure(figsize=(4.5,3.0))
+                plt.figure(figsize=(4.5, 3.0))
                 plt.xlabel(xaxisLabel)
                 plt.ylabel(yaxisLabel)
-                plt.scatter(PhiCoords[2], FitYVals[2], color='dodgerblue', label = "Vert. Array Puncture 1")
-                plt.scatter(PhiCoords[0], FitYVals[0], color='dodgerblue', marker='^', label = "Vert. Array Puncture 2")
-                plt.plot(xvalues, yvalues, color='orange', label = "Asymmetric Gaussian Fit")
-                plt.scatter(PhiCoords[1], FitYVals[1], color='limegreen', label = "Hor. Array Puncture 1")
-                plt.scatter(PhiCoords[3], FitYVals[3], color='limegreen', marker='^', label = "Hor. Array Puncture 2")
-                plt.legend(ncol=2, loc='center right', bbox_to_anchor=(0.42, -0.3))
+                plt.scatter(
+                    PhiCoords[2],
+                    FitYVals[2],
+                    color="dodgerblue",
+                    label="Vert. Array Puncture 1",
+                )
+                plt.scatter(
+                    PhiCoords[0],
+                    FitYVals[0],
+                    color="dodgerblue",
+                    marker="^",
+                    label="Vert. Array Puncture 2",
+                )
+                plt.plot(
+                    xvalues, yvalues, color="orange", label="Asymmetric Gaussian Fit"
+                )
+                plt.scatter(
+                    PhiCoords[1],
+                    FitYVals[1],
+                    color="limegreen",
+                    label="Hor. Array Puncture 1",
+                )
+                plt.scatter(
+                    PhiCoords[3],
+                    FitYVals[3],
+                    color="limegreen",
+                    marker="^",
+                    label="Hor. Array Puncture 2",
+                )
+                plt.legend(ncol=2, loc="center right", bbox_to_anchor=(0.42, -0.3))
                 plt.tight_layout()
             else:
-                plt.figure(figsize=(4.5,4.0))
+                plt.figure(figsize=(4.5, 4.0))
                 plt.xlabel(xaxisLabel)
                 plt.ylabel(yaxisLabel)
-                plt.scatter(PhiCoords, FitYVals, label = "Puncture Values")
-                plt.plot(xvalues, yvalues, color='orange', label = "Toroidal Dist.")
-                plt.legend(ncol=1, loc='upper right', bbox_to_anchor=(1.0, 1.0))
+                plt.scatter(PhiCoords, FitYVals, label="Puncture Values")
+                plt.plot(xvalues, yvalues, color="orange", label="Toroidal Dist.")
+                plt.legend(ncol=1, loc="upper right", bbox_to_anchor=(1.0, 1.0))
                 plt.tight_layout()
             plt.show()
         return sigmaLeft, sigmaRight, amplitude, mu
 
     def calc_rad_error(self, PvalCutoff, MovePeak):
         # finds error bar ranges of rad power and tpf for a single timestep
-        
+
         if not self.errorDists:
-            raise Exception("Must run calc_fits with ErrorPool=True before calc_rad_error")
-        
+            raise Exception(
+                "Must run calc_fits with ErrorPool=True before calc_rad_error"
+            )
+
         errorRadPowers = []
         errorTpfs = []
         for distNum in range(len(self.errorDists)):
             try:
-                errorRadPower, errorExtrasPowers, errorTpf, errorToroidalFitCoeffs =\
-                    self.calc_rad_power(RadDist=self.errorDists[distNum], PreScale=self.errorPrescales[distNum],\
-                        FitsFirsts=self.errorFitsFirsts[distNum], FitsSeconds=self.errorFitsSeconds[distNum],\
-                        MovePeak=MovePeak)
+                errorRadPower, errorExtrasPowers, errorTpf, errorToroidalFitCoeffs = (
+                    self.calc_rad_power(
+                        RadDist=self.errorDists[distNum],
+                        PreScale=self.errorPrescales[distNum],
+                        FitsFirsts=self.errorFitsFirsts[distNum],
+                        FitsSeconds=self.errorFitsSeconds[distNum],
+                        MovePeak=MovePeak,
+                    )
+                )
                 errorRadPowers.append(errorRadPower)
                 errorTpfs.append(errorTpf)
             except:
-                print("The toroidal distribution fitting of \
+                print(
+                    "The toroidal distribution fitting of \
                       a helical distribution in pool of reasonable fits \
-                      was unable to converge at this time")
-        
+                      was unable to converge at this time"
+                )
+
         self.lowerBoundPower = min(errorRadPowers)
         self.upperBoundPower = max(errorRadPowers)
         self.lowerBoundTpf = min(errorTpfs)
         self.upperBoundTpf = max(errorTpfs)
-            
+
         self.lowerBoundRadPowers.append(self.lowerBoundPower)
         self.upperBoundRadPowers.append(self.upperBoundPower)
         self.lowerBoundTpfs.append(self.lowerBoundTpf)
         self.upperBoundTpfs.append(self.upperBoundTpf)
-            
+
         print("Lower Bound Rad Power is " + str(self.lowerBoundPower))
         print("Upper Bound Rad Power is " + str(self.upperBoundPower))
-            
-    def calc_tot_rad(self, TimePerStep, NumTimes = 11,\
-                     ErrorPool = False, PvalCutoff = 0.9545, MovePeak=False):
+
+    def calc_tot_rad(
+        self,
+        TimePerStep,
+        NumTimes=11,
+        ErrorPool=False,
+        PvalCutoff=0.9545,
+        MovePeak=False,
+    ):
         # finds total radiated energy for entire shot. Stores timestep-by-timestep best fit
         # information in the process, and error bound information if ErrorPool=True
-        
+
         self.radPowers = []
         self.extrasPowers = []
         self.tpfs = []
@@ -738,26 +1098,30 @@ class Emis3D(object):
         self.minchisqList = []
         self.minpvalList = []
         self.minTorFitCoeffs = []
-        
+
         wrad = 0.0
         upperwrad = 0.0
         lowerwrad = 0.0
         self.accumWrads = []
         self.upperAccumWrads = []
         self.lowerAccumWrads = []
-        
+
         self.errorDists = []
         self.lowerBoundRadPowers = []
         self.upperBoundRadPowers = []
         self.lowerBoundTpfs = []
         self.upperBoundTpfs = []
-        
+
         for timeIndex in range(NumTimes):
             print(" ")
             print("calculating time " + str(timeIndex) + "/" + str(NumTimes))
-            
-            self.calc_fits(Etime=self.radPowerTimes[timeIndex], ErrorPool=ErrorPool, PvalCutoff=PvalCutoff)
-                
+
+            self.calc_fits(
+                Etime=self.radPowerTimes[timeIndex],
+                ErrorPool=ErrorPool,
+                PvalCutoff=PvalCutoff,
+            )
+
             print("Best Fit RadDist Type = " + self.minDistType)
             self.minRadDistList.append(self.minRadDist)
             self.minPreScaleList.append(self.minPreScale)
@@ -765,52 +1129,77 @@ class Emis3D(object):
             self.minFitsSeconds.append(self.bestFitsBoloSeconds)
             self.minchisqList.append(self.minchisq)
             self.minpvalList.append(self.minpval)
-                
-            radPower, extrasPowers, tpf, torFitCoeffs =\
-                self.calc_rad_power(RadDist=self.minRadDist, PreScale=self.minPreScale,\
-                        FitsFirsts=self.bestFitsBoloFirsts, FitsSeconds=self.bestFitsBoloSeconds,\
-                        MovePeak=MovePeak)
-                
+
+            radPower, extrasPowers, tpf, torFitCoeffs = self.calc_rad_power(
+                RadDist=self.minRadDist,
+                PreScale=self.minPreScale,
+                FitsFirsts=self.bestFitsBoloFirsts,
+                FitsSeconds=self.bestFitsBoloSeconds,
+                MovePeak=MovePeak,
+            )
+
             self.radPowers.append(radPower)
             self.extrasPowers.append(extrasPowers)
             self.tpfs.append(tpf)
             self.minTorFitCoeffs.append(torFitCoeffs)
-                
+
             print("Rad Power in GW is " + str(radPower * 1e-9))
             print("TPF is " + str(tpf))
-            
+
             if ErrorPool:
                 self.calc_rad_error(PvalCutoff=PvalCutoff, MovePeak=MovePeak)
-            
+
             wrad = wrad + (radPower * TimePerStep)
             upperwrad = upperwrad + (self.upperBoundPower * TimePerStep)
-            lowerwrad = lowerwrad + (self.lowerBoundPower*TimePerStep)
+            lowerwrad = lowerwrad + (self.lowerBoundPower * TimePerStep)
             self.accumWrads.append(wrad)
             self.upperAccumWrads.append(upperwrad)
             self.lowerAccumWrads.append(lowerwrad)
-            
+
         self.totWrad = self.accumWrads[-1]
         self.upperTotWrad = self.upperAccumWrads[-1]
         self.lowerTotWrad = self.lowerAccumWrads[-1]
-    
+
     def output_to_excel(self):
         # Output data from Emis3D as an excel file
 
         import pandas as pd
-        
+
         # choose which variables to output to file, and what names they get in excel file
-        vars_to_print = ["radPowerTimes", "minchisqList", "lowerBoundRadPowers", "radPowers",\
-                        "upperBoundRadPowers", "lowerBoundTpfs", "tpfs", "upperBoundTpfs",\
-                        "minRadDistList", "minRadDistList", "minRadDistList", "minRadDistList",\
-                        "minRadDistList"]
-        excel_names = ["Time (s)", "Best Chisq", "Prad Lower (GW)", "Prad Best (GW)",\
-                        "Prad Upper (GW)", "TPF Lower", "TPF Best", "TPF Upper",\
-                        "Best Fit Type", "polSigma", "startR", "startZ",\
-                        "elongation"]
-        
+        vars_to_print = [
+            "radPowerTimes",
+            "minchisqList",
+            "lowerBoundRadPowers",
+            "radPowers",
+            "upperBoundRadPowers",
+            "lowerBoundTpfs",
+            "tpfs",
+            "upperBoundTpfs",
+            "minRadDistList",
+            "minRadDistList",
+            "minRadDistList",
+            "minRadDistList",
+            "minRadDistList",
+        ]
+        excel_names = [
+            "Time (s)",
+            "Best Chisq",
+            "Prad Lower (GW)",
+            "Prad Best (GW)",
+            "Prad Upper (GW)",
+            "TPF Lower",
+            "TPF Best",
+            "TPF Upper",
+            "Best Fit Type",
+            "polSigma",
+            "startR",
+            "startZ",
+            "elongation",
+        ]
+
         # copy all attributes of Emis3D instance as dictionary
         varsDict = copy(vars(self))
-                
+
         # make new dictionary with only desired variables, renamed and ordered as excel_names
         outputDict = {}
         for name in excel_names:
@@ -829,29 +1218,33 @@ class Emis3D(object):
                         newvalues.append(None)
                 values = newvalues
             outputDict[name] = values
-        
+
         # convert to pandas dataframe
         outputDf = pd.DataFrame.from_dict(outputDict)
-        
+
         # output as excel
-        writer = pd.ExcelWriter(join(self.data_output_directory, str(self.shotnumber) + ".xlsx"))
+        writer = pd.ExcelWriter(
+            join(self.data_output_directory, str(self.shotnumber) + ".xlsx")
+        )
         outputDf.to_excel(writer, sheet_name=str(self.shotnumber), startcol=0)
-            
+
         # add any additional tokamak-specific variables to dictionary
         try:
             outputExtrasDict = self.tok_specific_output_data()
             outputExtrasDf = pd.DataFrame.from_dict(outputExtrasDict)
-            outputExtrasDf.to_excel(writer, sheet_name=str(self.shotnumber),\
-                                    startcol=len(excel_names) + 2)
+            outputExtrasDf.to_excel(
+                writer, sheet_name=str(self.shotnumber), startcol=len(excel_names) + 2
+            )
         except:
             pass
-        
+
         # close excel writer
         writer.close()
-    
-    def plot_radDist_array(self, PlotData, Levels,\
-                                  Lengthx, Lengthy, Etime, ColorBarLabel, PlotDistType):
-        
+
+    def plot_radDist_array(
+        self, PlotData, Levels, Lengthx, Lengthy, Etime, ColorBarLabel, PlotDistType
+    ):
+
         # Pull only RadDists of given type to be plotted
         plotRVecs = []
         plotZVecs = []
@@ -860,198 +1253,303 @@ class Emis3D(object):
                 thisRadDist = self.allRadDistsVec[distNum]
                 plotRVecs.append(thisRadDist.startR)
                 plotZVecs.append(thisRadDist.startZ)
-                
+
         # Create Figure
         fig = plt.figure(figsize=(Lengthx, Lengthy))
         ax = fig.add_subplot()
-        ax.set_aspect('equal')
-        ax.set_xlabel('$R$ (m)')
-        ax.set_ylabel('$Z$ (m)')
-        
+        ax.set_aspect("equal")
+        ax.set_xlabel("$R$ (m)")
+        ax.set_ylabel("$Z$ (m)")
+
         # Create color contour of fits
-        tcf = ax.tricontourf(plotRVecs, plotZVecs, PlotData,\
-            levels=Levels, cmap='gist_stern')
-        ax.plot(plotRVecs, plotZVecs, 'xk')
-        
+        tcf = ax.tricontourf(
+            plotRVecs, plotZVecs, PlotData, levels=Levels, cmap="gist_stern"
+        )
+        ax.plot(plotRVecs, plotZVecs, "xk")
+
         # Add white x and circle around best fit
         if self.minDistType == PlotDistType:
             bestRadDist = self.allRadDistsVec[self.minInd]
             r = bestRadDist.startR
             z = bestRadDist.startZ
-            ax.plot(r, z, 'o', markeredgecolor='white', fillstyle='none', 
-                    markeredgewidth=3, markersize=40)
-            ax.plot(r, z, 'x', markeredgecolor='white')
-            
+            ax.plot(
+                r,
+                z,
+                "o",
+                markeredgecolor="white",
+                fillstyle="none",
+                markeredgewidth=3,
+                markersize=40,
+            )
+            ax.plot(r, z, "x", markeredgecolor="white")
+
         # Set plot dimensions
-        ax.set_xlim([self.tokamakAMode.majorRadius - (1.1*self.tokamakAMode.minorRadius),\
-                     self.tokamakAMode.majorRadius + (1.1*self.tokamakAMode.minorRadius)])
-        ax.set_ylim([(-2.4*self.tokamakAMode.minorRadius),\
-                     (2.4*self.tokamakAMode.minorRadius)])
-            
+        ax.set_xlim(
+            [
+                self.tokamakAMode.majorRadius - (1.1 * self.tokamakAMode.minorRadius),
+                self.tokamakAMode.majorRadius + (1.1 * self.tokamakAMode.minorRadius),
+            ]
+        )
+        ax.set_ylim(
+            [
+                (-2.4 * self.tokamakAMode.minorRadius),
+                (2.4 * self.tokamakAMode.minorRadius),
+            ]
+        )
+
         # Set plot title
         ax.set_title(str(PlotDistType) + "s")
-        
+
         # Set colorbar
-        fig.colorbar(tcf, ax=ax, label=ColorBarLabel, shrink=0.5, format='%d')
-        
+        fig.colorbar(tcf, ax=ax, label=ColorBarLabel, shrink=0.5, format="%d")
+
         # Plot first wall curve
-        r = self.tokamakAMode.wallcurve.vertices[:,0]
-        z = self.tokamakAMode.wallcurve.vertices[:,1]
-        ax.plot(r,z, 'orange')
-        
+        r = self.tokamakAMode.wallcurve.vertices[:, 0]
+        z = self.tokamakAMode.wallcurve.vertices[:, 1]
+        ax.plot(r, z, "orange")
+
         # Plot Q=1.1,2, and 3 surfaces
-        r, z = self.tokamakAMode.get_qsurface_contour(Shotnumber=self.shotnumber, EvalTime=Etime-5e-4, Qval=1.1)
-        ax.plot(r,z, "cyan")
-        r, z = self.tokamakAMode.get_qsurface_contour(Shotnumber=self.shotnumber, EvalTime=Etime-5e-4, Qval=2.0)
-        ax.plot(r,z, "cyan")
-        r, z = self.tokamakAMode.get_qsurface_contour(Shotnumber=self.shotnumber, EvalTime=Etime-5e-4, Qval=3.0)
-        ax.plot(r,z, "cyan")
-        r, z = self.tokamakAMode.get_qsurface_contour(Shotnumber=self.shotnumber, EvalTime=Etime-5e-4, Qval="Separatrix")
-        ax.plot(r,z, "cyan")
-        
+        # r, z = self.tokamakAMode.get_qsurface_contour(
+        #    Shotnumber=self.shotnumber, EvalTime=Etime - 5e-4, Qval=1.1
+        # )
+        ax.plot(r, z, "cyan")
+        r, z = self.tokamakAMode.get_qsurface_contour(
+            Shotnumber=self.shotnumber, EvalTime=Etime - 5e-4, Qval=2.0
+        )
+        ax.plot(r, z, "cyan")
+        r, z = self.tokamakAMode.get_qsurface_contour(
+            Shotnumber=self.shotnumber, EvalTime=Etime - 5e-4, Qval=3.0
+        )
+        ax.plot(r, z, "cyan")
+        r, z = self.tokamakAMode.get_qsurface_contour(
+            Shotnumber=self.shotnumber, EvalTime=Etime - 5e-4, Qval="Separatrix"
+        )
+        ax.plot(r, z, "cyan")
+
         return fig
-    
-    def plot_fits_array(self, Lengthx=3, Lengthy=4, Etime = 50.89, PlotDistType = "Helical"):
-        
+
+    def plot_fits_array(
+        self, Lengthx=3, Lengthy=4, Etime=50.89, PlotDistType="Helical"
+    ):
+
         if not self.pvalVec:
             raise Exception("Must calculate p values before plotting fits")
-            
+
         # Pull only RadDists of given type to be plotted
         plotChisq = []
         for distNum in range(len(self.allRadDistsVec)):
             if self.allRadDistsVec[distNum].distType == PlotDistType:
                 plotChisq.append(self.chisqVec[distNum])
-        
-        levels = np.linspace(0, 40., num=20)
-        
-        fig = self.plot_radDist_array(\
-            PlotData=plotChisq, Levels=levels, Lengthx=Lengthx, Lengthy=Lengthy, Etime=Etime,\
-            ColorBarLabel='$\chi^2_r$', PlotDistType=PlotDistType)
-        
+
+        levels = np.linspace(0, 40.0, num=20)
+
+        fig = self.plot_radDist_array(
+            PlotData=plotChisq,
+            Levels=levels,
+            Lengthx=Lengthx,
+            Lengthy=Lengthy,
+            Etime=Etime,
+            ColorBarLabel="$\chi^2_r$",
+            PlotDistType=PlotDistType,
+        )
+
         return fig
-         
-    def plot_powers_array(self, Lengthx=3, Lengthy=4, Etime = 50.89, PlotDistType = "Helical",\
-                          MovePeak=False):
-        
+
+    def plot_powers_array(
+        self, Lengthx=3, Lengthy=4, Etime=50.89, PlotDistType="Helical", MovePeak=False
+    ):
+
         if not self.pvalVec:
             raise Exception("Must calculate p values before plotting powers")
-    
+
         # Pull only RadDists of given type to be plotted
         plotDistsRadPowers = []
         for distNum in range(len(self.allRadDistsVec)):
             if self.allRadDistsVec[distNum].distType == PlotDistType:
                 thisRadDist = self.allRadDistsVec[distNum]
-                
-                radPower = self.calc_rad_power(RadDist=thisRadDist, PreScale=self.preScaleVec[distNum],\
-                    FitsFirsts=self.fitsBoloFirsts[distNum], FitsSeconds=self.fitsBoloSeconds[distNum],\
-                    MovePeak=MovePeak)[0]
+
+                radPower = self.calc_rad_power(
+                    RadDist=thisRadDist,
+                    PreScale=self.preScaleVec[distNum],
+                    FitsFirsts=self.fitsBoloFirsts[distNum],
+                    FitsSeconds=self.fitsBoloSeconds[distNum],
+                    MovePeak=MovePeak,
+                )[0]
 
                 plotDistsRadPowers.append(radPower)
-                
+
         bestFitRadDist = self.allRadDistsVec[self.minInd]
-        bestFitRadPower = self.calc_rad_power(RadDist=bestFitRadDist, PreScale=self.preScaleVec[self.minInd],\
-                    FitsFirsts=self.fitsBoloFirsts[self.minInd], FitsSeconds=self.fitsBoloSeconds[self.minInd],\
-                    MovePeak=MovePeak)[0]
+        bestFitRadPower = self.calc_rad_power(
+            RadDist=bestFitRadDist,
+            PreScale=self.preScaleVec[self.minInd],
+            FitsFirsts=self.fitsBoloFirsts[self.minInd],
+            FitsSeconds=self.fitsBoloSeconds[self.minInd],
+            MovePeak=MovePeak,
+        )[0]
         print("Best Fit Rad Power is " + str(bestFitRadPower / 1e9) + "GW")
-        
-        #This step removes very high outliers that screw up the plot
-        #medPower = np.median(plotDistsRadPowers)
-        
+
+        # This step removes very high outliers that screw up the plot
+        # medPower = np.median(plotDistsRadPowers)
+
         for i in range(len(plotDistsRadPowers)):
             if plotDistsRadPowers[i] > (10.0 * bestFitRadPower):
                 plotDistsRadPowers[i] = 0.0
             elif np.isnan(plotDistsRadPowers[i]):
                 plotDistsRadPowers[i] = 0.0
-        
-        levels = np.linspace(0, max(plotDistsRadPowers)/1e9, num=20)
-        
-        fig = self.plot_radDist_array(\
-            PlotData=np.array(plotDistsRadPowers)/1e9, Levels=levels,\
-            Lengthx=Lengthx, Lengthy=Lengthy, Etime=Etime,\
-            ColorBarLabel='$P_{rad}$ (GW)', PlotDistType = PlotDistType)
-        
+
+        levels = np.linspace(0, max(plotDistsRadPowers) / 1e9, num=20)
+
+        fig = self.plot_radDist_array(
+            PlotData=np.array(plotDistsRadPowers) / 1e9,
+            Levels=levels,
+            Lengthx=Lengthx,
+            Lengthy=Lengthy,
+            Etime=Etime,
+            ColorBarLabel="$P_{rad}$ (GW)",
+            PlotDistType=PlotDistType,
+        )
+
         return fig
-    
-    def plot_fits_channels(self, Etime = 50.89, AsBrightness = True):
-        
-        bolo_exp, synthArrayFirst, synthArraySecond = self.plot_fits_data_organization(Etime=Etime)
-        
-        fig, axs = plt.subplots(self.numTorLocs, 1, figsize=(3,2*self.numTorLocs))
-        
+
+    def plot_fits_channels(self, Etime=50.89, AsBrightness=True):
+
+        bolo_exp, synthArrayFirst, synthArraySecond = self.plot_fits_data_organization(
+            Etime=Etime
+        )
+
+        fig, axs = plt.subplots(self.numTorLocs, 1, figsize=(3, 2 * self.numTorLocs))
+
         channel_errs = self.channel_errs
-        
+
         for numTor in range(self.numTorLocs):
             ax = axs[numTor]
-    
-            #Remove error bars that are larger than measurement itself, just for plotting
+
+            # Remove error bars that are larger than measurement itself, just for plotting
             for errIndex in range(len(channel_errs[numTor])):
                 try:
-                    if abs(channel_errs[numTor][errIndex]) > abs(bolo_exp[numTor][errIndex]):
+                    if abs(channel_errs[numTor][errIndex]) > abs(
+                        bolo_exp[numTor][errIndex]
+                    ):
                         channel_errs[numTor][errIndex] = 0.0
                 except:
                     pass
-                    
+
             # convert to power per m^2
             if AsBrightness:
                 for i in range(len(bolo_exp[numTor])):
-                    bolo_exp[numTor][i] = bolo_exp[numTor][i] * 4.0 * math.pi / self.bolo_etendues[numTor][i]
-                    synthArrayFirst[numTor][i] = synthArrayFirst[numTor][i] * 4.0 * math.pi / self.bolo_etendues[numTor][i]
+                    bolo_exp[numTor][i] = (
+                        bolo_exp[numTor][i]
+                        * 4.0
+                        * math.pi
+                        / self.bolo_etendues[numTor][i]
+                    )
+                    synthArrayFirst[numTor][i] = (
+                        synthArrayFirst[numTor][i]
+                        * 4.0
+                        * math.pi
+                        / self.bolo_etendues[numTor][i]
+                    )
                     # only works if there is a second puncture, otherwise length of list is wrong
                     try:
-                        synthArraySecond[numTor][i] = synthArraySecond[numTor][i] * 4.0 * math.pi / self.bolo_etendues[numTor][i]
+                        synthArraySecond[numTor][i] = (
+                            synthArraySecond[numTor][i]
+                            * 4.0
+                            * math.pi
+                            / self.bolo_etendues[numTor][i]
+                        )
                     except:
                         pass
-                
 
                 # for MW / m^2
                 ax.set_ylabel(r"Power Location " + str(numTor) + " $(MW/m^2)$")
                 bolo_exp[numTor] = [x * 1e-6 for x in bolo_exp[numTor]]
-                channel_errs[numTor] = [x * 1e-6 for x in channel_errs[numTor]]    
+                channel_errs[numTor] = [x * 1e-6 for x in channel_errs[numTor]]
                 synthArrayFirst[numTor] = [x * 1e-6 for x in synthArrayFirst[numTor]]
                 try:
-                    synthArraySecond[numTor] = [x * 1e-6 for x in synthArraySecond[numTor]]
+                    synthArraySecond[numTor] = [
+                        x * 1e-6 for x in synthArraySecond[numTor]
+                    ]
                 except:
                     pass
-            
+
             else:
                 # for watts
                 multiplier = 1.0
                 ax.set_ylabel(r"Power Location " + str(numTor) + " $(W)$")
                 # for milliwatts
-                #multiplier =1e3
-                #ax.set_ylabel(r"Power Location " + str(numTor) + " $(mW)$")
-                
+                # multiplier =1e3
+                # ax.set_ylabel(r"Power Location " + str(numTor) + " $(mW)$")
+
                 bolo_exp[numTor] = [x * multiplier for x in bolo_exp[numTor]]
-                channel_errs[numTor] = [x * multiplier for x in channel_errs[numTor]]    
-                synthArrayFirst[numTor] = [x * multiplier for x in synthArrayFirst[numTor]]    
-                synthArraySecond[numTor] = [x * multiplier for x in synthArraySecond[numTor]] 
-            
+                channel_errs[numTor] = [x * multiplier for x in channel_errs[numTor]]
+                synthArrayFirst[numTor] = [
+                    x * multiplier for x in synthArrayFirst[numTor]
+                ]
+                synthArraySecond[numTor] = [
+                    x * multiplier for x in synthArraySecond[numTor]
+                ]
+
             channelNum = range(len(bolo_exp[numTor]))
             try:
-                ax.errorbar(channelNum, bolo_exp[numTor], yerr=channel_errs[numTor], label='Experiment', color='blue')
+                ax.errorbar(
+                    channelNum,
+                    bolo_exp[numTor],
+                    yerr=channel_errs[numTor],
+                    label="Experiment",
+                    color="blue",
+                )
             except:
-                ax.plot(channelNum, bolo_exp[numTor], label='Experiment', color='blue')
-            ax.plot(channelNum, synthArrayFirst[numTor], '-s', label='1st Puncture', color='gray')
+                ax.plot(channelNum, bolo_exp[numTor], label="Experiment", color="blue")
+            ax.plot(
+                channelNum,
+                synthArrayFirst[numTor],
+                "-s",
+                label="1st Puncture",
+                color="gray",
+            )
             try:
-                ax.plot(channelNum, synthArraySecond[numTor], '-x', label='2nd Puncture', color='gray')
-                ax.plot(channelNum, ([synthArrayFirst[numTor][i] + synthArraySecond[numTor][i]\
-                    for i in range(len(synthArrayFirst[numTor]))]),\
-                    '-o', label='Full Synthetic', color='green')
+                ax.plot(
+                    channelNum,
+                    synthArraySecond[numTor],
+                    "-x",
+                    label="2nd Puncture",
+                    color="gray",
+                )
+                ax.plot(
+                    channelNum,
+                    (
+                        [
+                            synthArrayFirst[numTor][i] + synthArraySecond[numTor][i]
+                            for i in range(len(synthArrayFirst[numTor]))
+                        ]
+                    ),
+                    "-o",
+                    label="Full Synthetic",
+                    color="green",
+                )
             except:
                 pass
-            ax.yaxis.set_major_formatter(FormatStrFormatter('%.2f'))
-        
+            ax.yaxis.set_major_formatter(FormatStrFormatter("%.2f"))
+
         plt.tight_layout()
-        
+
         return fig
-    
-    def save_bolos_contour_plot(self, Times, Bolo_vals,\
-            Title, SaveName, SaveFolder,\
-            LowerBound=4, UpperBound=8.2, NumTicks=22):
-        
+
+    def save_bolos_contour_plot(
+        self,
+        Times,
+        Bolo_vals,
+        Title,
+        SaveName,
+        SaveFolder,
+        LowerBound=4,
+        UpperBound=8.2,
+        NumTicks=22,
+    ):
+
         channel_list = np.array(range(len(Bolo_vals)))
         x, y = np.meshgrid(Times, channel_list)
-        
+
         plot_vals = copy(Bolo_vals)
         for row in range(len(plot_vals)):
             for indx in range(len(plot_vals[row])):
@@ -1059,34 +1557,49 @@ class Emis3D(object):
                     plot_vals[row][indx] = np.log10(plot_vals[row][indx])
                 else:
                     plot_vals[row][indx] = np.nan
-        
-        fig,ax=plt.subplots(1,1)
-        cp = ax.contourf(x, y, plot_vals, levels = np.linspace(LowerBound, UpperBound, NumTicks), cmap="jet")
+
+        fig, ax = plt.subplots(1, 1)
+        cp = ax.contourf(
+            x,
+            y,
+            plot_vals,
+            levels=np.linspace(LowerBound, UpperBound, NumTicks),
+            cmap="jet",
+        )
         colorbar = fig.colorbar(cp)
         colorbar.ax.set_ylabel("Log(Brightness [$W/m^2$])")
         ax.set_title(Title)
-        ax.set_ylabel('Channel Number')
-        ax.set_xlabel('Time [s]')
+        ax.set_ylabel("Channel Number")
+        ax.set_xlabel("Time [s]")
         savefile = join(SaveFolder, SaveName) + ".png"
-        plt.savefig(savefile, format='png')
-        
+        plt.savefig(savefile, format="png")
+
         plt.close(fig)
-        
-    def save_synth_contour_plot(self, ArrayNum, SaveName, SaveFolder,\
-                                PreviousArrayNum=None, NumChannels=None, LowerBound=1e4):
-        
+
+    def save_synth_contour_plot(
+        self,
+        ArrayNum,
+        SaveName,
+        SaveFolder,
+        PreviousArrayNum=None,
+        NumChannels=None,
+        LowerBound=1e4,
+    ):
+
         numTimes = len(self.radPowerTimes)
-        if NumChannels==None:
-            numChannels=0
-            bolo_powers_1st = self.rearrange_powers_array(self.minRadDistList[0].boloCameras_powers)
+        if NumChannels == None:
+            numChannels = 0
+            bolo_powers_1st = self.rearrange_powers_array(
+                self.minRadDistList[0].boloCameras_powers
+            )
             if hasattr(bolo_powers_1st[ArrayNum][0], "len"):
                 for subCameraNum in range(len(bolo_powers_1st[ArrayNum])):
                     numChannels += len(bolo_powers_1st[ArrayNum][subCameraNum])
             else:
                 numChannels += len(bolo_powers_1st[ArrayNum])
         else:
-            numChannels=NumChannels
-        
+            numChannels = NumChannels
+
         etendues = self.bolo_etendues[ArrayNum]
         bolos = np.zeros([numTimes, numChannels])
         for timeIndx in range(numTimes):
@@ -1095,207 +1608,309 @@ class Emis3D(object):
             preScale = self.minPreScaleList[timeIndx]
             minRadDist = copy(self.minRadDistList[timeIndx])
             for channelIndx in range(numChannels):
-                boloValue=0.0
-                bolo_powers = self.rearrange_powers_array(self.minRadDistList[timeIndx].boloCameras_powers)
-                bolo_powers_2nd = self.rearrange_powers_array(self.minRadDistList[timeIndx].boloCameras_powers_2nd)
+                boloValue = 0.0
+                bolo_powers = self.rearrange_powers_array(
+                    self.minRadDistList[timeIndx].boloCameras_powers
+                )
+                bolo_powers_2nd = self.rearrange_powers_array(
+                    self.minRadDistList[timeIndx].boloCameras_powers_2nd
+                )
                 if hasattr(bolo_powers[ArrayNum][0], "len"):
                     for subCameraNum in range(len(bolo_powers[ArrayNum])):
-                        boloValue = bolo_powers[ArrayNum][subCameraNum][channelIndx]\
-                            * preScale * plotFitsFirsts[ArrayNum]
-                        if hasattr(bolo_powers_2nd[ArrayNum][subCameraNum], "len")\
-                            and PreviousArrayNum != None:
-                            boloValue += bolo_powers_2nd[ArrayNum][subCameraNum][channelIndx]\
-                                * preScale * plotFitsFirsts[PreviousArrayNum] * plotFitsSeconds[ArrayNum]
+                        boloValue = (
+                            bolo_powers[ArrayNum][subCameraNum][channelIndx]
+                            * preScale
+                            * plotFitsFirsts[ArrayNum]
+                        )
+                        if (
+                            hasattr(bolo_powers_2nd[ArrayNum][subCameraNum], "len")
+                            and PreviousArrayNum != None
+                        ):
+                            boloValue += (
+                                bolo_powers_2nd[ArrayNum][subCameraNum][channelIndx]
+                                * preScale
+                                * plotFitsFirsts[PreviousArrayNum]
+                                * plotFitsSeconds[ArrayNum]
+                            )
                 else:
-                    boloValue = bolo_powers[ArrayNum][channelIndx]\
-                        * preScale * plotFitsFirsts[ArrayNum]
-                    if hasattr(minRadDist.boloCameras_powers_2nd[ArrayNum], "len")\
-                        and PreviousArrayNum != None:
-                        boloValue += bolo_powers_2nd[ArrayNum][channelIndx]\
-                            * preScale * plotFitsFirsts[PreviousArrayNum] * plotFitsSeconds[ArrayNum]
+                    boloValue = (
+                        bolo_powers[ArrayNum][channelIndx]
+                        * preScale
+                        * plotFitsFirsts[ArrayNum]
+                    )
+                    if (
+                        hasattr(minRadDist.boloCameras_powers_2nd[ArrayNum], "len")
+                        and PreviousArrayNum != None
+                    ):
+                        boloValue += (
+                            bolo_powers_2nd[ArrayNum][channelIndx]
+                            * preScale
+                            * plotFitsFirsts[PreviousArrayNum]
+                            * plotFitsSeconds[ArrayNum]
+                        )
                 boloValue = boloValue * 4.0 * math.pi / etendues[channelIndx]
                 bolos[timeIndx][channelIndx] = boloValue
-        
+
         # sets lower bound to plot values
         for i in range(numTimes):
             for j in range(numChannels):
                 if bolos[i][j] < LowerBound:
                     bolos[i][j] = LowerBound
-                
+
         bolos = bolos.T
-        
-        self.save_bolos_contour_plot(Times = self.radPowerTimes, Bolo_vals = bolos,\
-            Title = "Array " + str(ArrayNum) + " Best Fit Brightnesses\nDischarge " + str(self.shotnumber),\
-            SaveName = SaveName,\
-            SaveFolder = SaveFolder)
-        
-    def save_exp_contour_plot(self, ArrayNum, Title, SaveName, SaveFolder,\
-        StartTime=None, EndTime=None, EndChannel=None, DeleteChannels=None):
-        
-        if StartTime==None and EndTime==None:
+
+        self.save_bolos_contour_plot(
+            Times=self.radPowerTimes,
+            Bolo_vals=bolos,
+            Title="Array "
+            + str(ArrayNum)
+            + " Best Fit Brightnesses\nDischarge "
+            + str(self.shotnumber),
+            SaveName=SaveName,
+            SaveFolder=SaveFolder,
+        )
+
+    def save_exp_contour_plot(
+        self,
+        ArrayNum,
+        Title,
+        SaveName,
+        SaveFolder,
+        StartTime=None,
+        EndTime=None,
+        EndChannel=None,
+        DeleteChannels=None,
+    ):
+
+        if StartTime == None and EndTime == None:
             startTime = self.radPowerTimes[0]
             endTime = self.radPowerTimes[-1]
         else:
-            startTime=StartTime
-            endTime=EndTime
-        
+            startTime = StartTime
+            endTime = EndTime
+
         if EndChannel != None:
-            expData = self.load_bolo_exp_timerange(StartTime=startTime, EndTime=endTime,\
-                AsBrightnesses=True)[ArrayNum][:EndChannel]
+            expData = self.load_bolo_exp_timerange(
+                StartTime=startTime, EndTime=endTime, AsBrightnesses=True
+            )[ArrayNum][:EndChannel]
         else:
-            expData = self.load_bolo_exp_timerange(StartTime=startTime, EndTime=endTime,\
-            AsBrightnesses=True)[ArrayNum]
-            
-        expTimebase = self.load_bolo_timebase_range(StartTime=startTime, EndTime=endTime)[ArrayNum]
-        
+            expData = self.load_bolo_exp_timerange(
+                StartTime=startTime, EndTime=endTime, AsBrightnesses=True
+            )[ArrayNum]
+
+        expTimebase = self.load_bolo_timebase_range(
+            StartTime=startTime, EndTime=endTime
+        )[ArrayNum]
+
         if DeleteChannels != None:
             for indx in range(len(DeleteChannels)):
                 channel = DeleteChannels[indx]
                 expData[channel] = np.array([np.nan] * len(expData[channel]))
-        
-        self.save_bolos_contour_plot(Times = expTimebase, Bolo_vals = expData,\
-            Title = Title, SaveName = SaveName, SaveFolder = SaveFolder)
-        
-    def save_sim_contour_plot(self, ArrayNum, Title, SaveName, SaveFolder,\
-        EndChannel=None, DeleteChannels=None):
-        
+
+        self.save_bolos_contour_plot(
+            Times=expTimebase,
+            Bolo_vals=expData,
+            Title=Title,
+            SaveName=SaveName,
+            SaveFolder=SaveFolder,
+        )
+
+    def save_sim_contour_plot(
+        self,
+        ArrayNum,
+        Title,
+        SaveName,
+        SaveFolder,
+        EndChannel=None,
+        DeleteChannels=None,
+    ):
+
         simData = copy(self.bolo_sim)
-        
+
         for timeIndx in range(len(simData)):
             simData[timeIndx] = self.rearrange_powers_array(Powers=simData[timeIndx])
-        
+
         if EndChannel != None:
             for timeIndx in range(len(simData)):
                 simData[timeIndx] = simData[timeIndx][ArrayNum][:EndChannel]
         else:
             for timeIndx in range(len(simData)):
                 simData[timeIndx] = simData[timeIndx][ArrayNum]
-        
+
         for timeIndx in range(len(simData)):
             for channelIndx in range(len(simData[timeIndx])):
                 boloValue = simData[timeIndx][channelIndx]
-                boloValue = boloValue * 4.0 * math.pi / self.bolo_etendues[ArrayNum][channelIndx]
+                boloValue = (
+                    boloValue
+                    * 4.0
+                    * math.pi
+                    / self.bolo_etendues[ArrayNum][channelIndx]
+                )
                 simData[timeIndx][channelIndx] = boloValue
-        
+
         simData = np.array(simData).T
-        
+
         simTimebase = self.radPowerTimes
-        
+
         if DeleteChannels != None:
             for indx in range(len(DeleteChannels)):
                 channel = DeleteChannels[indx]
                 simData[channel] = np.array([np.nan] * len(simData[channel]))
-        
-        self.save_bolos_contour_plot(Times = simTimebase, Bolo_vals = simData,\
-            Title = Title, SaveName = SaveName, SaveFolder = SaveFolder)
-        
+
+        self.save_bolos_contour_plot(
+            Times=simTimebase,
+            Bolo_vals=simData,
+            Title=Title,
+            SaveName=SaveName,
+            SaveFolder=SaveFolder,
+        )
+
     def make_crossSec_movie(self, Phi=None, MovePeak=False):
 
         import cv2
-        
-        if Phi==None:
-            Phi=self.tokamakAMode.injectionPhiTor
+
+        if Phi == None:
+            Phi = self.tokamakAMode.injectionPhiTor
 
         self.load_tokamak(Mode="Build")
         numFillZeros = len(str(len(self.minRadDistList)))
         for radDistNum in range(len(self.minRadDistList)):
-            savefile = join(self.videos_output_directory, "crossSecImg") +\
-                        str(radDistNum).zfill(numFillZeros) + ".png"
+            savefile = (
+                join(self.videos_output_directory, "crossSecImg")
+                + str(radDistNum).zfill(numFillZeros)
+                + ".png"
+            )
             radDist = copy(self.minRadDistList[radDistNum])
             radDist.set_tokamak(self.tokamakBMode)
             radDist.make_build_mode()
-            
+
             if radDist.distType == "Helical":
 
-                sigmaLeft, sigmaRight, amplitude, mu =\
-                    self.find_asym_gaussian_parameters(\
-                    FitsFirsts=self.minFitsFirsts[radDistNum],\
-                    FitsSeconds=self.minFitsSeconds[radDistNum], MovePeak=MovePeak)
+                sigmaLeft, sigmaRight, amplitude, mu = (
+                    self.find_asym_gaussian_parameters(
+                        FitsFirsts=self.minFitsFirsts[radDistNum],
+                        FitsSeconds=self.minFitsSeconds[radDistNum],
+                        MovePeak=MovePeak,
+                    )
+                )
 
                 def torDistFunc(Phi0):
-                    val = self.asymmetric_gaussian_arr(Phi=Phi0, SigmaLeft=sigmaLeft, SigmaRight=sigmaRight,\
-                        Amplitude=amplitude, Mu=mu)
+                    val = self.asymmetric_gaussian_arr(
+                        Phi=Phi0,
+                        SigmaLeft=sigmaLeft,
+                        SigmaRight=sigmaRight,
+                        Amplitude=amplitude,
+                        Mu=mu,
+                    )
                     return val
 
-                crossSecPlot = radDist.plot_crossSec(Phi=Phi, TorDistFunc = torDistFunc)
+                crossSecPlot = radDist.plot_crossSec(Phi=Phi, TorDistFunc=torDistFunc)
             else:
                 crossSecPlot = radDist.plot_crossSec(Phi=Phi)
 
-            crossSecPlot.savefig(savefile, format='png')
+            crossSecPlot.savefig(savefile, format="png")
             plt.close(crossSecPlot)
 
         video_name = join(self.videos_output_directory, "crossSecs.avi")
 
-        images = [img for img in listdir(self.videos_output_directory)\
-            if img.endswith(".png") and img.startswith('crossSecImg')]
+        images = [
+            img
+            for img in listdir(self.videos_output_directory)
+            if img.endswith(".png") and img.startswith("crossSecImg")
+        ]
         images.sort()
         frame = cv2.imread(join(self.videos_output_directory, images[0]))
         height, width, layers = frame.shape
 
-        video = cv2.VideoWriter(video_name, 0, 1, (width,height))
+        video = cv2.VideoWriter(video_name, 0, 1, (width, height))
 
         for image in images:
             video.write(cv2.imread(join(self.videos_output_directory, image)))
-            
+
         for radDistNum in range(len(self.minRadDistList)):
-            savefile = join(self.videos_output_directory, "crossSecImg") +\
-                        str(radDistNum).zfill(numFillZeros) + ".png"
+            savefile = (
+                join(self.videos_output_directory, "crossSecImg")
+                + str(radDistNum).zfill(numFillZeros)
+                + ".png"
+            )
             remove(savefile)
 
         video.release()
 
-    def make_unwrapped_movie(self,\
-        Resolution = 30, Alpha = 0.005, SpotSize=20, MovePeak=False):
+    def make_unwrapped_movie(
+        self, Resolution=30, Alpha=0.005, SpotSize=20, MovePeak=False
+    ):
         import cv2
 
         self.load_tokamak(Mode="Build")
         numFillZeros = len(str(len(self.minRadDistList)))
-        
+
         for radDistNum in range(len(self.minRadDistList)):
-            savefile = join(self.videos_output_directory, "radDistImg") +\
-                        str(radDistNum).zfill(numFillZeros) + ".png"
+            savefile = (
+                join(self.videos_output_directory, "radDistImg")
+                + str(radDistNum).zfill(numFillZeros)
+                + ".png"
+            )
             radDist = copy(self.minRadDistList[radDistNum])
             radDist.set_tokamak(self.tokamakBMode)
             radDist.make_build_mode()
-            
+
             if radDist.distType == "Helical":
 
-                sigmaLeft, sigmaRight, amplitude, mu =\
-                    self.find_asym_gaussian_parameters(\
-                    FitsFirsts=self.minFitsFirsts[radDistNum],\
-                    FitsSeconds=self.minFitsSeconds[radDistNum], MovePeak=MovePeak)
+                sigmaLeft, sigmaRight, amplitude, mu = (
+                    self.find_asym_gaussian_parameters(
+                        FitsFirsts=self.minFitsFirsts[radDistNum],
+                        FitsSeconds=self.minFitsSeconds[radDistNum],
+                        MovePeak=MovePeak,
+                    )
+                )
 
                 def torDistFunc(Phi0):
-                    val = self.asymmetric_gaussian_arr(Phi=Phi0, SigmaLeft=sigmaLeft, SigmaRight=sigmaRight,\
-                        Amplitude=amplitude, Mu=mu)
+                    val = self.asymmetric_gaussian_arr(
+                        Phi=Phi0,
+                        SigmaLeft=sigmaLeft,
+                        SigmaRight=sigmaRight,
+                        Amplitude=amplitude,
+                        Mu=mu,
+                    )
                     return val
 
-                radDistPlot = radDist.plot_unwrapped(TorDistFunc = torDistFunc,\
-                    SpotSize = SpotSize, Resolution=Resolution, Alpha=Alpha)
+                radDistPlot = radDist.plot_unwrapped(
+                    TorDistFunc=torDistFunc,
+                    SpotSize=SpotSize,
+                    Resolution=Resolution,
+                    Alpha=Alpha,
+                )
             else:
-                radDistPlot = radDist.plot_unwrapped(\
-                    SpotSize = SpotSize, Resolution=Resolution, Alpha=Alpha)
-            
-            
-            radDistPlot.savefig(savefile, format='png')
+                radDistPlot = radDist.plot_unwrapped(
+                    SpotSize=SpotSize, Resolution=Resolution, Alpha=Alpha
+                )
+
+            radDistPlot.savefig(savefile, format="png")
             plt.close(radDistPlot)
 
         video_name = join(self.videos_output_directory, "unwrapped.avi")
 
-        images = [img for img in listdir(self.videos_output_directory) if img.endswith(".png") and img.startswith('radDistImg')]
+        images = [
+            img
+            for img in listdir(self.videos_output_directory)
+            if img.endswith(".png") and img.startswith("radDistImg")
+        ]
         images.sort()
         frame = cv2.imread(join(self.videos_output_directory, images[0]))
         height, width, layers = frame.shape
 
-        video = cv2.VideoWriter(video_name, 0, 1, (width,height))
+        video = cv2.VideoWriter(video_name, 0, 1, (width, height))
 
         for image in images:
             video.write(cv2.imread(join(self.videos_output_directory, image)))
 
         for radDistNum in range(len(self.minRadDistList)):
-            savefile = join(self.videos_output_directory, "radDistImg") +\
-                        str(radDistNum).zfill(numFillZeros) + ".png"
+            savefile = (
+                join(self.videos_output_directory, "radDistImg")
+                + str(radDistNum).zfill(numFillZeros)
+                + ".png"
+            )
             remove(savefile)
 
         video.release()
-

--- a/Emis3D_Main/RadDist.py
+++ b/Emis3D_Main/RadDist.py
@@ -4,16 +4,17 @@ Created on Fri Jun 11 13:12:06 2021
 
 @author: bemst
 """
-import numpy as np
-import math
-import matplotlib.pyplot as plt
-import random
-import time
-import sys
-from os.path import join
 import json
-from Util import XY_To_RPhi, RPhi_To_XY
-from Diagnostic import Synth_Brightness_Observer
+import math
+import random
+import sys
+import time
+from copy import deepcopy
+from os.path import join
+
+import matplotlib.pyplot as plt
+import numpy as np
+from cherab.tools.emitters import RadiationFunction
 
 # raysect dependencies
 from raysect.core.math import translate
@@ -21,21 +22,30 @@ from raysect.core.math.random import seed as raysectseed
 from raysect.optical.material import VolumeTransform
 from raysect.primitive import Cylinder
 
-from cherab.tools.emitters import RadiationFunction
+from Diagnostic import Synth_Brightness_Observer
+from Util import RPhi_To_XY, XY_To_RPhi
 
-from copy import deepcopy
 
 class RadDist(object):
-    
-    def __init__(self, NumBins = 18, NumPuncs = 2, Tokamak = None,\
-                Mode = "Analysis", LoadFileName = None, SaveFileFolder=None,\
-                TorSegmented=False):
-        #[creates radiation distribution from a given evaluate function]
-        
+
+    def __init__(
+        self,
+        NumBins=18,
+        NumPuncs=2,
+        Tokamak=None,
+        Mode="Analysis",
+        LoadFileName=None,
+        SaveFileFolder=None,
+        TorSegmented=False,
+    ):
+        # [creates radiation distribution from a given evaluate function]
+
         self.tokamak = Tokamak
-        self.saveFileFolder=SaveFileFolder
-        self.torSegmented=TorSegmented
-        self.randSeed = 10 # arbitrary. Just always using the same one so results don't vary
+        self.saveFileFolder = SaveFileFolder
+        self.torSegmented = TorSegmented
+        self.randSeed = (
+            10  # arbitrary. Just always using the same one so results don't vary
+        )
 
         if LoadFileName == None:
             self.numBins = NumBins
@@ -71,15 +81,23 @@ class RadDist(object):
             self.boloCameras_powers_2nd = properties["boloCameras_powers_2nd"]
             if "boloCameras_powers_extras" in properties:
                 self.boloCameras_powers_extras = properties["boloCameras_powers_extras"]
-                self.boloCameras_powers_extras_2nd = properties["boloCameras_powers_extras_2nd"]
+                self.boloCameras_powers_extras_2nd = properties[
+                    "boloCameras_powers_extras_2nd"
+                ]
             self.powerPerBin = properties["powerPerBin"]
             if self.torSegmented:
                 try:
                     self.bolo_powers_segmented = properties["bolo_powers_segmented"]
-                    self.bolo_powers_segmented_2nd = properties["bolo_powers_segmented_2nd"]
+                    self.bolo_powers_segmented_2nd = properties[
+                        "bolo_powers_segmented_2nd"
+                    ]
                     if "bolo_powers_extras_segmented" in properties:
-                        self.bolo_powers_extras_segmented = properties["bolo_powers_extras_segmented"]
-                        self.bolo_powers_extras_segmented_2nd = properties["bolo_powers_extras_segmented_2nd"]
+                        self.bolo_powers_extras_segmented = properties[
+                            "bolo_powers_extras_segmented"
+                        ]
+                        self.bolo_powers_extras_segmented_2nd = properties[
+                            "bolo_powers_extras_segmented_2nd"
+                        ]
 
                     self.tempObserverBin = None
                 except:
@@ -90,27 +108,29 @@ class RadDist(object):
 
     def set_tokamak(self, Tokamak):
         self.tokamak = Tokamak
-    
+
     def prepare_for_JSON(self, properties):
-        
+
         # JSON doesn't know how to deal with objects; just save names to
         # rebuild if necessary
         if self.torSegmented:
             properties.pop("tempObserverBin")
-        
+
         properties["tokamakName"] = self.tokamak.tokamakName
         properties.pop("tokamak")
         properties.pop("torSegmented")
-        
+
         return properties
-    
+
     def build(self):
         if self.tokamak.mode != "Build":
-            print("The tokamak object of this RadDist is not in Build mode. To use this function,\
+            print(
+                "The tokamak object of this RadDist is not in Build mode. To use this function,\
                   Either pass Tokamak = [a tokamak object with mode == 'Build'], or pass Tokamak = None and Mode = 'Build'\
-                  to this RadDist")
+                  to this RadDist"
+            )
             sys.exit(1)
-            
+
         self.power_per_bin_calc()
         self.bolos_observe()
         self.save_RadDist()
@@ -118,65 +138,279 @@ class RadDist(object):
             self.save_RadDist_Complete()
         except:
             pass
-    
-    def evaluate_first_punc(self, X,Y,Z):
+
+    def evaluate_first_punc(self, X, Y, Z):
         # is the 0 in phi<0 here hardcoded to SPARC injector location? Probably.
         # if we ever go to multiple injector Emis3D fitting, will need to adjust
         if self.torSegmented:
-            r,phi = XY_To_RPhi(X,Y)
-            if(phi < 0):
-               phi =  phi + 2*np.pi
+            r, phi = XY_To_RPhi(X, Y)
+            if phi < 0:
+                phi = phi + 2 * np.pi
             t = self.tempObserverBin
-            inc = np.pi/((self.numBins/2))
+            inc = np.pi / ((self.numBins / 2))
             binPhi = inc * t
-            if(phi >= binPhi and phi < (binPhi + inc)):
-                return self.evaluate(X,Y,Z, EvalFirstPunc=1, EvalSecondPunc=0)
-            else:
-                return 0    
-        else:
-            return self.evaluate(X,Y,Z, EvalFirstPunc=1, EvalSecondPunc=0)
-    
-    def evaluate_second_punc(self, X,Y,Z):
-        if self.torSegmented:
-            r,phi = XY_To_RPhi(X,Y)
-            if(phi < 0):
-              phi =  phi + 2*np.pi
-            t = self.tempObserverBin
-            inc = np.pi/((self.numBins/2))
-            binPhi = inc * t
-            if(phi >= binPhi and phi < (binPhi + inc)):
-                return self.evaluate(X,Y,Z, EvalFirstPunc=0, EvalSecondPunc=1)
+            if phi >= binPhi and phi < (binPhi + inc):
+                return self.evaluate(X, Y, Z, EvalFirstPunc=1, EvalSecondPunc=0)
             else:
                 return 0
-        else:    
-            return self.evaluate(X,Y,Z, EvalFirstPunc=0, EvalSecondPunc=1)
-        
-    def evaluate_both_punc(self, X,Y,Z):
-        return self.evaluate_first_punc(X,Y,Z) + self.evaluate_second_punc(X,Y,Z)
-        
-    def evaluate_first_punc_cherab(self, X,Y,Z):
+        else:
+            return self.evaluate(X, Y, Z, EvalFirstPunc=1, EvalSecondPunc=0)
+
+    def evaluate_second_punc(self, X, Y, Z):
+        if self.torSegmented:
+            r, phi = XY_To_RPhi(X, Y)
+            if phi < 0:
+                phi = phi + 2 * np.pi
+            t = self.tempObserverBin
+            inc = np.pi / ((self.numBins / 2))
+            binPhi = inc * t
+            if phi >= binPhi and phi < (binPhi + inc):
+                return self.evaluate(X, Y, Z, EvalFirstPunc=0, EvalSecondPunc=1)
+            else:
+                return 0
+        else:
+            return self.evaluate(X, Y, Z, EvalFirstPunc=0, EvalSecondPunc=1)
+
+    def evaluate_both_punc(self, X, Y, Z):
+        return self.evaluate_first_punc(X, Y, Z) + self.evaluate_second_punc(X, Y, Z)
+
+    def evaluate_first_punc_cherab(self, X, Y, Z):
         # Various tokamaks use different toroidal angle conventions than Cherab. Emis3D uses the Cherab
         # Angle convention. self.tokamak.torConventionPhi accounts for this difference
 
-        r, phi = XY_To_RPhi(X,Y)
-        x,y = RPhi_To_XY(r, phi - self.tokamak.torConventionPhi)
-                
-        return self.evaluate_first_punc(x,y,Z)
-    
-    def evaluate_second_punc_cherab(self, X,Y,Z):
-        
-        r, phi = XY_To_RPhi(X,Y)
-        x,y = RPhi_To_XY(r, phi - self.tokamak.torConventionPhi)
-        
-        return self.evaluate_second_punc(x,y,Z)
-    
-    def evaluate_both_punc_cherab(self, X,Y,Z):
-        r, phi = XY_To_RPhi(X,Y)
-        x,y = RPhi_To_XY(r, phi - self.tokamak.torConventionPhi)
-        evalBoth = self.evaluate_first_punc(x,y,Z) + self.evaluate_second_punc(x,y,Z)
+        r, phi = XY_To_RPhi(X, Y)
+        x, y = RPhi_To_XY(r, phi - self.tokamak.torConventionPhi)
+
+        return self.evaluate_first_punc(x, y, Z)
+
+    def evaluate_second_punc_cherab(self, X, Y, Z):
+
+        r, phi = XY_To_RPhi(X, Y)
+        x, y = RPhi_To_XY(r, phi - self.tokamak.torConventionPhi)
+
+        return self.evaluate_second_punc(x, y, Z)
+
+    def evaluate_both_punc_cherab(self, X, Y, Z):
+        r, phi = XY_To_RPhi(X, Y)
+        x, y = RPhi_To_XY(r, phi - self.tokamak.torConventionPhi)
+        evalBoth = self.evaluate_first_punc(x, y, Z) + self.evaluate_second_punc(
+            x, y, Z
+        )
         return evalBoth
-    
-    def power_per_bin_calc(self, Errfrac = 0.01, Pointsupdate = int(1e5)):
+
+    def power_per_bin_calc_fast(self, Errfrac=0.01, Pointsupdate=int(1e5)):
+        """
+        Replaces the power_per_bin_calc with a vectorized version.
+
+        One will also need to update the tokamak class with the new function:
+
+        def find_RZ_Fline_fast(self, Phi):
+            '''
+            Method based on Divakr's answer here:
+            https://stackoverflow.com/questions/45349561/find-nearest-indices-for-one-array-against-all-values-in-another-array-python
+            '''
+            B = np.array(self.fLinePhi)
+            A = np.array(Phi)
+            L = np.array(B).size
+            sidx_B = B.argsort()
+            sorted_B = B[sidx_B]
+            sorted_idx = np.searchsorted(sorted_B, A)
+            sorted_idx[sorted_idx == L] = L - 1
+            mask = (sorted_idx > 0) & (
+                (np.abs(A - sorted_B[sorted_idx - 1]) < np.abs(A - sorted_B[sorted_idx]))
+            )
+            flInd = sidx_B[sorted_idx - mask]
+            return self.fLineR[flInd], self.fLineZ[flInd]
+
+        One will also need to update their favorite radDist with _evalulate_fast, see Helical
+        for an example.
+        """
+        # set random seed to always be the same so that the result is not different every run
+        random.seed(self.randSeed)
+
+        # Function for choosing a random point inside a given rotationally-
+        # symmetric volume, where the cross section curve is given as a matplotlib
+        # path.
+        # Chooses a random point in a rectangular region containing the volume,
+        # checks if the point is inside the volume, and repeats until it finds
+        # a point that is in the torus.
+        def _random_uniform_point_noVolume(Wallcurve, Minr, Maxr, Minz, Maxz):
+
+            success = 0
+            while success == 0:
+                x = random.uniform(-Maxr, Maxr)
+                y = random.uniform(-Maxr, Maxr)
+                z = random.uniform(Minz, Maxz)
+                r = np.sqrt((x**2) + (y**2))
+
+                if r < Minr or r > Maxr:
+                    pass
+                elif Wallcurve.contains_points([(r, z)]):
+                    success = 1
+
+            return x, y, z, r
+
+        # Various possible errors
+        if (self.numPuncs != 1) and (self.numPuncs != 2):
+            print(
+                "Radiation integration code is only designed for one or two\
+                  \npunctures (toroidal cycles). For values between one and two,\
+                      \nuse two."
+            )
+            sys.exit(1)
+
+        if not isinstance(self.numBins, int) or self.numBins < 1 or self.numBins > 360:
+            print("Number of toroidal bins must be an integer between 1 and 360.")
+            sys.exit(1)
+
+        if Errfrac <= 0:
+            print("Desired error must be a positive number.")
+            sys.exit(1)
+
+        if self.tokamak.volume <= 0:
+            print(
+                "Volume of first wall region must be a positive number (in meters^3)."
+            )
+            sys.exit(1)
+
+        if not isinstance(Pointsupdate, int):
+            print(
+                "Update frequency ('Pointsupdate') must be an integer greater than 0."
+            )
+            sys.exit(1)
+
+        if Pointsupdate < 1e4 or Pointsupdate > 1e7:
+            print(
+                "Warning: Update frequency ('Pointsupdate') is in an unusual range.\
+                  \nYou may receive status updates more or less frequently than desired."
+            )
+
+        if Errfrac < 0.005 or self.numBins > 36:
+            print(
+                "Warning: the desired accuracy is very precise, or the number of\
+                  \ntoroidal bins is very large. The integration may take a\
+                      \nlong time."
+            )
+
+        print(
+            "Warning: Very fine structure (order of 1 cm^3 or less) may\
+              \nnot appear in results, or cause program to take longer to run."
+        )
+        print("Warning: Time estimate is probably not accurate.")
+        print("integrating RadDist power ...")
+
+        # integration function really starts here
+        starttime = time.time()
+
+        # loading curve
+        wallcurve, minr, maxr, minz, maxz = (
+            self.tokamak.wallcurve,
+            self.tokamak.minr,
+            self.tokamak.maxr,
+            self.tokamak.minz,
+            self.tokamak.maxz,
+        )
+
+        # define constants and starting values
+        angleperbin = 2.0 * np.pi / self.numBins
+        volumeperbin = self.tokamak.volume / float(self.numBins)
+        pointsperbin = 0
+        reachedprecision = 0
+        emissumarray = np.zeros((self.numPuncs, self.numBins))
+        emissqsumarray = np.zeros((self.numPuncs, self.numBins))
+
+        while reachedprecision == 0:
+            pointsperbin += Pointsupdate
+            # --- Create all of the random points first
+            x_, y_, z_, R_, phifirstbin_ = [], [], [], [], []
+            while len(x_) < Pointsupdate:
+                x, y, z, R = _random_uniform_point_noVolume(
+                    wallcurve, minr, maxr, minz, maxz
+                )
+                x_.append(x)
+                y_.append(y)
+                z_.append(z)
+                R_.append(R)
+
+                # finds phi position, rotates to phi position in first bin
+                phi = XY_To_RPhi(x, y)[1]  # in radians
+                if phi < 0:
+                    phi += 2.0 * np.pi
+                phibin = math.floor(phi / angleperbin)
+                phifirstbin_.append(phi - (angleperbin * phibin))
+
+            # --- Evalulate all of the points at once
+            R_ = np.array(R_)
+            z_ = np.array(z_)
+
+            for numbin in range(0, self.numBins):
+                # --- use the initial point for each toroidal bin
+                phi = np.array(phifirstbin_) + (angleperbin * numbin)
+
+                # --- Finds the emission for each puncture...
+                for numpunc in range(1, self.numPuncs + 1):
+                    if numpunc == 1:
+                        EvalFirstPunc = 1.0
+                        EvalSecondPunc = 0.0
+                    elif numpunc == 2:
+                        EvalFirstPunc = 0.0
+                        EvalSecondPunc = 1.0
+                    # the way this approach handles second punctures may have a problem here; the field line follower gets
+                    # called for phi larger than 2 pi (because that's enforced above I guess?). Should check this carefully before second paper
+                    emission = self.evaluate_fast(
+                        R_, phi, z_, EvalFirstPunc, EvalSecondPunc
+                    )
+
+                    emissumarray[numpunc - 1, numbin] += emission.sum()
+                    emissqsumarray[numpunc - 1, numbin] += (emission**2).sum()
+
+            # --- Check to see if the desired precision is reached
+            emismeanarray = emissumarray / pointsperbin
+            emisvararray = (emissqsumarray / pointsperbin) - (emismeanarray**2)
+
+            integemisarray = volumeperbin * emismeanarray
+            totintegemis = np.sum(integemisarray)
+            integemisvararray = volumeperbin**2 * emisvararray / pointsperbin
+            integemiserrarray = np.sqrt(integemisvararray)
+            totintegemiserr = np.sum(integemiserrarray)
+            toterrfrac = totintegemiserr / totintegemis
+
+            if toterrfrac < Errfrac:
+                reachedprecision = 1
+            else:
+                print("total std. err fraction so far = " + str(toterrfrac))
+                timeremainest = 140.0 * ((toterrfrac / Errfrac) - 1.0) ** (1.0 / 2.0)
+                # print("random points checked per bin so far = " + str(pointsperbin))
+                runtime = time.time() - starttime
+                print("time so far = " + str(math.ceil(runtime)) + " seconds")
+                try:
+                    print(
+                        "rough estimated time remaining = "
+                        + str(math.ceil(timeremainest))
+                        + " seconds"
+                    )
+                except:
+                    print("rough estimated time remaining = NaN seconds")
+                print("")
+
+        # calculations of final radiation values and errors
+        emismeanarray = emissumarray / pointsperbin
+        emisvararray = (emissqsumarray / pointsperbin) - (emismeanarray**2)
+
+        integemisarray = volumeperbin * emismeanarray
+        totintegemis = np.sum(integemisarray)
+        integemisvararray = volumeperbin**2 * emisvararray / pointsperbin
+        integemiserrarray = np.sqrt(integemisvararray)
+        totintegemiserr = np.sum(integemiserrarray)
+        toterrfrac = totintegemiserr / totintegemis
+
+        self.powerPerBin = integemisarray.tolist()
+
+        runtime = time.time() - starttime
+        print("integration runtime = " + str(math.ceil(runtime)) + " seconds")
+        print("final error fraction = " + str(toterrfrac))
+
+    def power_per_bin_calc(self, Errfrac=0.01, Pointsupdate=int(1e5)):
         # Calculates total radiated power per solid angle emitted inside
         # a toroidal region with emissivity function from evaluate function
 
@@ -185,166 +419,182 @@ class RadDist(object):
 
         # Various possible errors
         if (self.numPuncs != 1) and (self.numPuncs != 2):
-            print("Radiation integration code is only designed for one or two\
+            print(
+                "Radiation integration code is only designed for one or two\
                   \npunctures (toroidal cycles). For values between one and two,\
-                      \nuse two.")
+                      \nuse two."
+            )
             sys.exit(1)
-            
+
         if not isinstance(self.numBins, int) or self.numBins < 1 or self.numBins > 360:
             print("Number of toroidal bins must be an integer between 1 and 360.")
             sys.exit(1)
-            
+
         if Errfrac <= 0:
             print("Desired error must be a positive number.")
             sys.exit(1)
-            
+
         if self.tokamak.volume <= 0:
-            print("Volume of first wall region must be a positive number (in meters^3).")
+            print(
+                "Volume of first wall region must be a positive number (in meters^3)."
+            )
             sys.exit(1)
-            
+
         if not isinstance(Pointsupdate, int):
-            print("Update frequency ('Pointsupdate') must be an integer greater than 0.")
+            print(
+                "Update frequency ('Pointsupdate') must be an integer greater than 0."
+            )
             sys.exit(1)
-            
+
         if Pointsupdate < 1e4 or Pointsupdate > 1e7:
-            print("Warning: Update frequency ('Pointsupdate') is in an unusual range.\
-                  \nYou may receive status updates more or less frequently than desired.")
-            
+            print(
+                "Warning: Update frequency ('Pointsupdate') is in an unusual range.\
+                  \nYou may receive status updates more or less frequently than desired."
+            )
+
         if Errfrac < 0.005 or self.numBins > 36:
-            print("Warning: the desired accuracy is very precise, or the number of\
+            print(
+                "Warning: the desired accuracy is very precise, or the number of\
                   \ntoroidal bins is very large. The integration may take a\
-                      \nlong time.")
-            
-        print("Warning: Very fine structure (order of 1 cm^3 or less) may\
-              \nnot appear in results, or cause program to take longer to run.")
+                      \nlong time."
+            )
+
+        print(
+            "Warning: Very fine structure (order of 1 cm^3 or less) may\
+              \nnot appear in results, or cause program to take longer to run."
+        )
         print("Warning: Time estimate is probably not accurate.")
         print("integrating RadDist power ...")
-        
+
         # integration function really starts here
         starttime = time.time()
-        
+
         # Function for choosing a random point inside a given rotationally-
         # symmetric volume, where the cross section curve is given as a matplotlib
         # path.
         # Chooses a random point in a rectangular region containing the volume,
         # checks if the point is inside the volume, and repeats until it finds
         # a point that is in the torus.
-        def random_uniform_point_noVolume(Wallcurve,\
-            Minr, Maxr, Minz, Maxz):
-            
+        def random_uniform_point_noVolume(Wallcurve, Minr, Maxr, Minz, Maxz):
+
             success = 0
             while success == 0:
                 x = random.uniform(-Maxr, Maxr)
                 y = random.uniform(-Maxr, Maxr)
                 z = random.uniform(Minz, Maxz)
-                r = np.sqrt((x**2)+(y**2))
-                
-                if (r < Minr or r > Maxr):
+                r = np.sqrt((x**2) + (y**2))
+
+                if r < Minr or r > Maxr:
                     pass
                 elif Wallcurve.contains_points([(r, z)]):
                     success = 1
-                    
+
             return x, y, z, r
-        
+
         # loading curve
-        wallcurve, minr, maxr, minz, maxz =\
-            self.tokamak.wallcurve, self.tokamak.minr, self.tokamak.maxr,\
-            self.tokamak.minz, self.tokamak.maxz
-        
+        wallcurve, minr, maxr, minz, maxz = (
+            self.tokamak.wallcurve,
+            self.tokamak.minr,
+            self.tokamak.maxr,
+            self.tokamak.minz,
+            self.tokamak.maxz,
+        )
+
         # define constants and starting values
-        angleperbin = 2. * np.pi / self.numBins
+        angleperbin = 2.0 * np.pi / self.numBins
         volumeperbin = self.tokamak.volume / float(self.numBins)
         pointsperbin = 0
         reachedprecision = 0
         emissumarray = np.zeros((self.numPuncs, self.numBins))
         emissqsumarray = np.zeros((self.numPuncs, self.numBins))
-        
+
         # calculates the mean and variance of emissivity inside the region
         # by evaluating at randomly chosen points throughout the region
         # and averaging.
         while reachedprecision == 0:
-            x, y, z, R\
-                = random_uniform_point_noVolume(wallcurve,\
-                minr, maxr, minz, maxz)
-           
+            x, y, z, R = random_uniform_point_noVolume(
+                wallcurve, minr, maxr, minz, maxz
+            )
+
             # finds phi position, rotates to phi position in first bin
-            phi = XY_To_RPhi(x,y)[1] # in radians
+            phi = XY_To_RPhi(x, y)[1]  # in radians
             if phi < 0:
-                phi += 2. * np.pi
+                phi += 2.0 * np.pi
             phibin = math.floor(phi / angleperbin)
             phifirstbin = phi - (angleperbin * phibin)
-            
+
             for numbin in range(0, self.numBins):
                 phi = phifirstbin + (angleperbin * numbin)
                 x, y = RPhi_To_XY(R, phi)
-                
-                for numpunc in range(1,self.numPuncs+1) :
+
+                for numpunc in range(1, self.numPuncs + 1):
                     if numpunc == 1:
-                        EvalFirstPunc = 1.
-                        EvalSecondPunc = 0.
+                        EvalFirstPunc = 1.0
+                        EvalSecondPunc = 0.0
                     elif numpunc == 2:
-                        EvalFirstPunc = 0.
-                        EvalSecondPunc = 1.
+                        EvalFirstPunc = 0.0
+                        EvalSecondPunc = 1.0
                     # the way this approach handles second punctures may have a problem here; the field line follower gets
                     # called for phi larger than 2 pi (because that's enforced above I guess?). Should check this carefully before second paper
-                    emission = self.evaluate(x,y,z, EvalFirstPunc, EvalSecondPunc)
-                    emissumarray[numpunc-1, numbin] += emission
-                    emissqsumarray[numpunc-1, numbin] += emission**2
-    
+                    emission = self.evaluate(x, y, z, EvalFirstPunc, EvalSecondPunc)
+                    emissumarray[numpunc - 1, numbin] += emission
+                    emissqsumarray[numpunc - 1, numbin] += emission**2
+
             pointsperbin += 1
-            
+
             # check if at desired error yet. If yes, show results and end program;
             # otherwise, continue choosing points
             if pointsperbin % Pointsupdate == 0:
                 emismeanarray = emissumarray / pointsperbin
-                emisvararray = (emissqsumarray / pointsperbin)\
-                    - (emismeanarray**2)
-                
+                emisvararray = (emissqsumarray / pointsperbin) - (emismeanarray**2)
+
                 integemisarray = volumeperbin * emismeanarray
                 totintegemis = np.sum(integemisarray)
-                integemisvararray = volumeperbin**2\
-                    * emisvararray / pointsperbin
+                integemisvararray = volumeperbin**2 * emisvararray / pointsperbin
                 integemiserrarray = np.sqrt(integemisvararray)
                 totintegemiserr = np.sum(integemiserrarray)
                 toterrfrac = totintegemiserr / totintegemis
-                
+
                 if toterrfrac < Errfrac:
                     reachedprecision = 1
                 else:
                     print("total std. err fraction so far = " + str(toterrfrac))
-                    timeremainest = 140.0 *\
-                        ((toterrfrac / Errfrac) - 1.0) ** (1.0/2.0)
-                    #print("random points checked per bin so far = " + str(pointsperbin))
+                    timeremainest = 140.0 * ((toterrfrac / Errfrac) - 1.0) ** (
+                        1.0 / 2.0
+                    )
+                    # print("random points checked per bin so far = " + str(pointsperbin))
                     runtime = time.time() - starttime
                     print("time so far = " + str(math.ceil(runtime)) + " seconds")
                     try:
-                        print("rough estimated time remaining = " + str(math.ceil(timeremainest)) + " seconds")
+                        print(
+                            "rough estimated time remaining = "
+                            + str(math.ceil(timeremainest))
+                            + " seconds"
+                        )
                     except:
                         print("rough estimated time remaining = NaN seconds")
                     print("")
-                    
+
         # calculations of final radiation values and errors
         emismeanarray = emissumarray / pointsperbin
-        emisvararray = (emissqsumarray / pointsperbin)\
-            - (emismeanarray**2)
-        
+        emisvararray = (emissqsumarray / pointsperbin) - (emismeanarray**2)
+
         integemisarray = volumeperbin * emismeanarray
         totintegemis = np.sum(integemisarray)
-        integemisvararray = volumeperbin**2\
-            * emisvararray / pointsperbin
+        integemisvararray = volumeperbin**2 * emisvararray / pointsperbin
         integemiserrarray = np.sqrt(integemisvararray)
         totintegemiserr = np.sum(integemiserrarray)
         toterrfrac = totintegemiserr / totintegemis
-        
+
         # possible outputs
-        #print("bin integrated emissivities = " + str(integemisarray))
-        #print("total integrated emissivity = " + str(totintegemis))
-        #print("bin integrated emissivity errors = " + str(integemiserrarray))
-        #print("total integrated emissivity error = " + str(totintegemiserr))
-        #print("total integrated emissivity error fraction = " + str(toterrfrac))
-        
+        # print("bin integrated emissivities = " + str(integemisarray))
+        # print("total integrated emissivity = " + str(totintegemis))
+        # print("bin integrated emissivity errors = " + str(integemiserrarray))
+        # print("total integrated emissivity error = " + str(totintegemiserr))
+        # print("total integrated emissivity error fraction = " + str(toterrfrac))
+
         self.powerPerBin = integemisarray.tolist()
-        
+
         runtime = time.time() - starttime
         print("integration runtime = " + str(math.ceil(runtime)) + " seconds")
         print("final error fraction = " + str(toterrfrac))
@@ -364,17 +614,19 @@ class RadDist(object):
     def bolos_observe(self):
 
         if self.tokamak.mode != "Build":
-            print("The tokamak object of this RadDist is not in Build mode. To use this function,\
+            print(
+                "The tokamak object of this RadDist is not in Build mode. To use this function,\
                   Either pass Tokamak = [a tokamak object with mode == 'Build'], or pass Tokamak = None and Mode = 'Build'\
-                  to this RadDist")
+                  to this RadDist"
+            )
             sys.exit(11)
-        
+
         # set random seed to always be the same so that the result is not different every run
         # doesn't seem to work though. some raysect developer comments on github suggest
         # this is a known issue...
         # https://github.com/ray-project/ray/issues/10145
         raysectseed(self.randSeed)
-            
+
         boloCameras = self.tokamak.bolometers
         boloExtras = self.tokamak.extrabolometers
         self.boloCameras_powers = []
@@ -386,7 +638,7 @@ class RadDist(object):
             self.bolo_powers_segmented_2nd = []
             self.bolo_powers_extras_segmented = []
             self.bolo_powers_extras_segmented_2nd = []
-        
+
         def assign_monte_carlo_iterations_loop(BolosList):
             for channel in BolosList:
                 try:
@@ -408,17 +660,21 @@ class RadDist(object):
             return BolosList
 
         for array in boloCameras:
-            array.bolometers = assign_monte_carlo_iterations_loop(BolosList=array.bolometers)
+            array.bolometers = assign_monte_carlo_iterations_loop(
+                BolosList=array.bolometers
+            )
 
         if len(boloExtras) > 0:
             for array in boloExtras:
-                array.bolometers = assign_monte_carlo_iterations_loop(BolosList=array.bolometers)
-        
+                array.bolometers = assign_monte_carlo_iterations_loop(
+                    BolosList=array.bolometers
+                )
+
         # The following lines define an emitting volume that the RadDist evaluate functions are embedded in.
         # The parameters are set to encompass to entirety of the tokamak (this setup is for JET and smaller), and the -2.5 is to shift the
         # volume so that it is vertically centered at  z = 0.
         # the first line defines the shape, the second makes it an emitting volume, the third embeds it in the world of the tokamak in question
-        # whoops I've hardcoded upper and lower height bounds... oh well. Can adjust that if we ever 
+        # whoops I've hardcoded upper and lower height bounds... oh well. Can adjust that if we ever
         # port this to a machine with larger than these. Use self.tokamak parameters probably
         emitter = Cylinder(radius=5, height=5, transform=translate(0, 0, -2.5))
         emitter.parent = self.tokamak.world
@@ -450,47 +706,63 @@ class RadDist(object):
             PowersArray.append(channel_powers)
 
             return arraynumber, PowersArray
-        
+
         def punctureLoop(PunctureNum):
             print("Observing puncture " + str(PunctureNum))
-            if PunctureNum==1:
-                emitter.material = VolumeTransform(RadiationFunction(\
-                    self.evaluate_first_punc_cherab), emitter.transform.inverse())
-            elif PunctureNum==2:
-                emitter.material = VolumeTransform(RadiationFunction(\
-                    self.evaluate_second_punc_cherab), emitter.transform.inverse())
+            if PunctureNum == 1:
+                emitter.material = VolumeTransform(
+                    RadiationFunction(self.evaluate_first_punc_cherab),
+                    emitter.transform.inverse(),
+                )
+            elif PunctureNum == 2:
+                emitter.material = VolumeTransform(
+                    RadiationFunction(self.evaluate_second_punc_cherab),
+                    emitter.transform.inverse(),
+                )
             powers_array = []
             arraynumber = 0
             for array in boloCameras:
-                arraynumber, powers_array = arrayLoop(\
-                    BolosArray=array, ArrayNumber=arraynumber, PowersArray=powers_array)
+                arraynumber, powers_array = arrayLoop(
+                    BolosArray=array, ArrayNumber=arraynumber, PowersArray=powers_array
+                )
 
             if len(boloExtras) > 0:
                 extras_powers_array = []
                 for array in boloExtras:
-                    arraynumber, extras_powers_array = arrayLoop(\
-                        BolosArray=array, ArrayNumber=arraynumber, PowersArray=extras_powers_array)
+                    arraynumber, extras_powers_array = arrayLoop(
+                        BolosArray=array,
+                        ArrayNumber=arraynumber,
+                        PowersArray=extras_powers_array,
+                    )
 
-            if PunctureNum==1:
+            if PunctureNum == 1:
                 if self.torSegmented:
                     self.bolo_powers_segmented = powers_array
-                    self.boloCameras_powers = self.bin_sum(Variable_seg=self.bolo_powers_segmented)
+                    self.boloCameras_powers = self.bin_sum(
+                        Variable_seg=self.bolo_powers_segmented
+                    )
 
                     if len(boloExtras) > 0:
                         self.bolo_powers_extras_segmented = extras_powers_array
-                        self.boloCameras_powers_extras = self.bin_sum(Variable_seg=self.bolo_powers_extras_segmented)
+                        self.boloCameras_powers_extras = self.bin_sum(
+                            Variable_seg=self.bolo_powers_extras_segmented
+                        )
                 else:
                     self.boloCameras_powers = powers_array
                     if len(boloExtras) > 0:
                         self.boloCameras_powers_extras = extras_powers_array
-            elif PunctureNum==2:
+            elif PunctureNum == 2:
                 if self.torSegmented:
                     self.bolo_powers_segmented_2nd = powers_array
-                    self.boloCameras_powers_2nd = self.bin_sum(Variable_seg=self.bolo_powers_segmented_2nd)
+                    self.boloCameras_powers_2nd = self.bin_sum(
+                        Variable_seg=self.bolo_powers_segmented_2nd
+                    )
 
                     if len(boloExtras) > 0:
                         self.bolo_powers_extras_segmented_2nd = extras_powers_array
-                        self.boloCameras_powers_extras_2nd = self.bin_sum(Variable_seg=self.bolo_powers_extras_segmented_2nd)
+                        self.boloCameras_powers_extras_2nd = self.bin_sum(
+                            Variable_seg=self.bolo_powers_extras_segmented_2nd
+                        )
                 else:
                     self.boloCameras_powers_2nd = powers_array
                     if len(boloExtras) > 0:
@@ -500,27 +772,30 @@ class RadDist(object):
         if (self.distType == "Helical") or (self.distType == "ElongatedHelical"):
             punctureLoop(PunctureNum=2)
 
-    def plot_in_round_old(self, Title = "Radiation Distribution",\
-                 FromWhite = False, Resolution = 60, Alpha = 0.05):
+    def plot_in_round_old(
+        self, Title="Radiation Distribution", FromWhite=False, Resolution=60, Alpha=0.05
+    ):
         # Makes a 3d plot of the RadDist. Does not include any toroidal distribution overlay.
         # Radiation magnitude is described by color. Very low value points are removed entirely,
         # giving the general radiation structure shape. Nevertheless, the internal radiation
         # structure is obscured by the external; such is 3d plotting. Adjust resolution and alpha for
         # better viewing.
-        
+
         # has angle of plotting off by pi/2
-        
+
         # The sundial shaped thing shows the bins into which radiated power is separated.
-        
+
         if self.tokamak.mode != "Build":
-            print("The tokamak object of this RadDist is not in Build mode. To use this function,\
+            print(
+                "The tokamak object of this RadDist is not in Build mode. To use this function,\
                   Either pass Tokamak = [a tokamak object with mode == 'Build'], or pass\
-                  Tokamak = None and Mode = 'Build' to this RadDist")
+                  Tokamak = None and Mode = 'Build' to this RadDist"
+            )
             sys.exit(1)
-            
+
         # just so the intervals are nice whole-ish numbers if Resolution is even
         resolution = Resolution + 1
-        
+
         # setup for tokamak sundial thing (shows inner first wall radius,
         # outer first wall radius, and bin dividers)
         theta = np.linspace(0, 2 * np.pi, resolution)
@@ -529,31 +804,40 @@ class RadDist(object):
         outerX = (majorRadius + minorRadius) * np.cos(theta)
         outerY = (majorRadius + minorRadius) * np.sin(theta)
         Z = np.zeros(Resolution + 1)
-        
+
         innerX = (majorRadius - minorRadius) * np.cos(theta)
         innerY = (majorRadius - minorRadius) * np.sin(theta)
-        
+
         # each column of these resulting arrays is for one line
-        binBorderThetas = np.reshape(np.linspace(0, 2 * np.pi, self.numBins+1), (1,-1))
-        borderNums = np.reshape(np.linspace(majorRadius - minorRadius,\
-                               majorRadius + minorRadius,\
-                                   resolution), (-1, 1))
+        binBorderThetas = np.reshape(
+            np.linspace(0, 2 * np.pi, self.numBins + 1), (1, -1)
+        )
+        borderNums = np.reshape(
+            np.linspace(
+                majorRadius - minorRadius, majorRadius + minorRadius, resolution
+            ),
+            (-1, 1),
+        )
         borderXs = borderNums @ np.cos(binBorderThetas)
         borderYs = borderNums @ np.sin(binBorderThetas)
-        
+
         # setup points for evaluate function bubble plot
         # xVec actually used for all 3 dimensions
-        xVec = np.linspace(-(majorRadius + minorRadius),\
-                    majorRadius + minorRadius, resolution)
+        xVec = np.linspace(
+            -(majorRadius + minorRadius), majorRadius + minorRadius, resolution
+        )
         evalXs, evalYs, evalZs = np.meshgrid(xVec, xVec, xVec)
         functionVals = np.zeros((resolution, resolution, resolution))
         for xValIndx in range(resolution):
             for yValIndx in range(resolution):
                 for zValIndx in range(resolution):
-                    functionVals[xValIndx, yValIndx, zValIndx] =\
-                        self.evaluate_both_punc(xVec[xValIndx], xVec[yValIndx], xVec[zValIndx])
+                    functionVals[xValIndx, yValIndx, zValIndx] = (
+                        self.evaluate_both_punc(
+                            xVec[xValIndx], xVec[yValIndx], xVec[zValIndx]
+                        )
+                    )
         functionVals = np.floor(255 * functionVals / np.max(functionVals)).astype(int)
-        
+
         evalXs = np.ravel(evalXs)
         evalYs = np.ravel(evalYs)
         evalZs = np.ravel(evalZs)
@@ -563,160 +847,182 @@ class RadDist(object):
         evalYs = np.delete(evalYs, negligible)
         evalZs = np.delete(evalZs, negligible)
         functionVals = np.delete(functionVals, negligible)
-        
+
         fig = plt.figure()
-        ax = plt.axes(projection = '3d')
+        ax = plt.axes(projection="3d")
         plotlimit = majorRadius + minorRadius
         ax.set_xlim3d(-plotlimit, plotlimit)
         ax.set_ylim3d(-plotlimit, plotlimit)
         ax.set_zlim3d(-plotlimit, plotlimit)
         # inboard midplane ring
-        ax.plot(innerX, innerY, Z, color = '#00ceaa')
+        ax.plot(innerX, innerY, Z, color="#00ceaa")
         # outboard midplane ring
-        ax.plot(outerX, outerY, Z, color = '#00ceaa')
+        ax.plot(outerX, outerY, Z, color="#00ceaa")
         # bin border lines
         for borderNum in range(self.numBins):
-            ax.plot(borderXs[:,borderNum], borderYs[:,borderNum], Z, color = '#00ceaa')
+            ax.plot(borderXs[:, borderNum], borderYs[:, borderNum], Z, color="#00ceaa")
         # evaluate function scatter plot.
         if FromWhite == True:
-            ax.scatter(evalXs, evalYs, evalZs, c = plt.cm.Purples(functionVals),
-                            alpha = Alpha)
+            ax.scatter(
+                evalXs, evalYs, evalZs, c=plt.cm.Purples(functionVals), alpha=Alpha
+            )
         else:
-            ax.scatter(evalXs, evalYs, evalZs, c = plt.cm.plasma(functionVals),
-                            alpha = Alpha)
-                    
+            ax.scatter(
+                evalXs, evalYs, evalZs, c=plt.cm.plasma(functionVals), alpha=Alpha
+            )
+
         ax.set_title(Title)
         ax.set_xlabel("X")
         ax.set_ylabel("Y")
         ax.set_zlabel("Z")
-        
+
         return fig
-    
-    def plot_in_round(self, Title = None, ShowFirstWall=True,\
-                FromWhite = False, Resolution = 10, Alpha = 0.1,\
-                PlotSightlines=False, ColoredSightlines=False, RemoveZeroSightlines=True):
-        
+
+    def plot_in_round(
+        self,
+        Title=None,
+        ShowFirstWall=True,
+        FromWhite=False,
+        Resolution=10,
+        Alpha=0.1,
+        PlotSightlines=False,
+        ColoredSightlines=False,
+        RemoveZeroSightlines=True,
+    ):
+
         # Makes a 3d plot of the RadDist. Does not include any toroidal distribution overlay.
         # Radiation magnitude is described by color. Very low value points are removed entirely,
         # giving the general radiation structure shape. Nevertheless, the internal radiation
         # structure is obscured by the external; such is 3d plotting. Adjust resolution and alpha for
         # better viewing.
-        
+
         if self.tokamak.mode != "Build":
-            print("The tokamak object of this RadDist is not in Build mode. To use this function,\
+            print(
+                "The tokamak object of this RadDist is not in Build mode. To use this function,\
                   Either pass Tokamak = [a tokamak object with mode == 'Build'], or pass\
-                  Tokamak = None and Mode = 'Build' to this RadDist")
+                  Tokamak = None and Mode = 'Build' to this RadDist"
+            )
             sys.exit(1)
-        
+
         majorRadius = self.tokamak.majorRadius
         minorRadius = self.tokamak.minorRadius
-        
+
         # just so the intervals are nice whole-ish numbers if Resolution is even
         resolution = Resolution + 1
-        
+
         # setup for rad power bubble plot thing
-        
+
         rRes = math.ceil(Resolution)
-        phiRes = math.ceil(3.0*np.pi*Resolution)
-        zRes = math.ceil(Resolution*2.2)
-        
+        phiRes = math.ceil(3.0 * np.pi * Resolution)
+        zRes = math.ceil(Resolution * 2.2)
+
         evalRs = np.linspace(majorRadius - minorRadius, majorRadius + minorRadius, rRes)
         evalPhis = np.linspace(-np.pi, np.pi, phiRes)
-        evalZs = np.linspace(-2.2*minorRadius, 2.2*minorRadius, zRes)
-                        
+        evalZs = np.linspace(-2.2 * minorRadius, 2.2 * minorRadius, zRes)
+
         functionVals = []
-        plotZs= []
-        plotXs=[]
-        plotYs=[]
-        
+        plotZs = []
+        plotXs = []
+        plotYs = []
+
         for evalR in evalRs:
             for evalZ in evalZs:
                 if self.tokamak.wallcurve.contains_points([(evalR, evalZ)]):
                     for evalPhi in evalPhis:
-                            evalX, evalY = RPhi_To_XY(evalR, evalPhi)
-                            
-                            functionVal = self.evaluate_both_punc(evalX, evalY, evalZ)
-                            plotZs.append(evalZ)
-                            plotXs.append(evalX)
-                            plotYs.append(evalY)
-                            functionVals.append(functionVal)
-        
+                        evalX, evalY = RPhi_To_XY(evalR, evalPhi)
+
+                        functionVal = self.evaluate_both_punc(evalX, evalY, evalZ)
+                        plotZs.append(evalZ)
+                        plotXs.append(evalX)
+                        plotYs.append(evalY)
+                        functionVals.append(functionVal)
+
         # convert to RGB scale
         functionMax = np.max(functionVals)
         functionVals = [math.floor(255 * x / functionMax) for x in functionVals]
         functionMax = np.max(functionVals)
-        
+
         # # Delete points where radiated power is less than 1% of maximum
         negligible = np.argwhere(functionVals < (0.01 * functionMax))
         functionVals = np.delete(functionVals, negligible)
         plotZs = np.delete(plotZs, negligible)
         plotXs = np.delete(plotXs, negligible)
         plotYs = np.delete(plotYs, negligible)
-        
+
         # create plot and set bounds
         fig = plt.figure()
-        ax = plt.axes(projection = '3d')
+        ax = plt.axes(projection="3d")
         plotlimit = majorRadius + minorRadius
         ax.set_xlim3d(-plotlimit, plotlimit)
         ax.set_ylim3d(-plotlimit, plotlimit)
         ax.set_zlim3d(-plotlimit, plotlimit)
-        
+
         # evaluate function scatter plot.
         if FromWhite:
-            ax.scatter(plotXs, plotYs, plotZs, c = plt.cm.Purples(functionVals),
-                            alpha = Alpha)
+            ax.scatter(
+                plotXs, plotYs, plotZs, c=plt.cm.Purples(functionVals), alpha=Alpha
+            )
         else:
-            ax.scatter(plotXs, plotYs, plotZs, c = plt.cm.plasma(functionVals),
-                            alpha = Alpha)
-            
+            ax.scatter(
+                plotXs, plotYs, plotZs, c=plt.cm.plasma(functionVals), alpha=Alpha
+            )
+
         # setup for tokamak sundial thing (shows inner first wall radius,
         # outer first wall radius, and bin dividers)
-        theta = np.linspace(0, 2 * np.pi, self.numBins+1)
+        theta = np.linspace(0, 2 * np.pi, self.numBins + 1)
         majorRadius = self.tokamak.majorRadius
         minorRadius = self.tokamak.minorRadius
         outerX = (majorRadius + minorRadius) * np.cos(theta)
         outerY = (majorRadius + minorRadius) * np.sin(theta)
-        outerZ = np.zeros(self.numBins+1)
-        
+        outerZ = np.zeros(self.numBins + 1)
+
         innerX = (majorRadius - minorRadius) * np.cos(theta)
         innerY = (majorRadius - minorRadius) * np.sin(theta)
-        innerZ = np.zeros(self.numBins+1)
-        
+        innerZ = np.zeros(self.numBins + 1)
+
         # each column of these resulting arrays is for one line
-        binBorderThetas = np.reshape(np.linspace(0, 2 * np.pi, self.numBins+1), (1,-1))
-        borderNums = np.reshape(np.linspace(majorRadius - minorRadius,\
-                               majorRadius + minorRadius,\
-                                   2), (-1, 1))
+        binBorderThetas = np.reshape(
+            np.linspace(0, 2 * np.pi, self.numBins + 1), (1, -1)
+        )
+        borderNums = np.reshape(
+            np.linspace(majorRadius - minorRadius, majorRadius + minorRadius, 2),
+            (-1, 1),
+        )
         borderXs = borderNums @ np.cos(binBorderThetas)
         borderYs = borderNums @ np.sin(binBorderThetas)
         borderZs = np.zeros(2)
-        
+
         # inboard midplane ring
-        ax.plot(innerX, innerY, innerZ, color = '#00ceaa')
+        ax.plot(innerX, innerY, innerZ, color="#00ceaa")
         # outboard midplane ring
-        ax.plot(outerX, outerY, outerZ, color = '#00ceaa')
+        ax.plot(outerX, outerY, outerZ, color="#00ceaa")
         # bin border lines
         for borderNum in range(self.numBins):
-            ax.plot(borderXs[:,borderNum], borderYs[:,borderNum], borderZs, color = '#00ceaa')
-          
+            ax.plot(
+                borderXs[:, borderNum],
+                borderYs[:, borderNum],
+                borderZs,
+                color="#00ceaa",
+            )
+
         # For plotting first wall contours
         if ShowFirstWall:
-            r = self.tokamak.wallcurve.vertices[:,0]
-            z = self.tokamak.wallcurve.vertices[:,1]
-            ax.plot3D(r,[0.0]*len(r),z, 'orange')
-            ax.plot3D(-1.0*r,[0.0]*len(r),z, 'orange')
-            ax.plot3D([0.0]*len(r), r, z, 'orange')
-            ax.plot3D([0.0]*len(r), -1.0*r, z, 'orange')
-        
-        if (Title is not None):
+            r = self.tokamak.wallcurve.vertices[:, 0]
+            z = self.tokamak.wallcurve.vertices[:, 1]
+            ax.plot3D(r, [0.0] * len(r), z, "orange")
+            ax.plot3D(-1.0 * r, [0.0] * len(r), z, "orange")
+            ax.plot3D([0.0] * len(r), r, z, "orange")
+            ax.plot3D([0.0] * len(r), -1.0 * r, z, "orange")
+
+        if Title is not None:
             ax.set_title(Title)
         ax.set_xlabel("X")
         ax.set_ylabel("Y")
         ax.set_zlabel("Z")
-        
+
         fig.subplots_adjust(left=0.1, right=0.9, bottom=0, top=0.9)
         plt.tight_layout()
-        
+
         """
         ax.set_xticks([])
         ax.set_yticks([])
@@ -736,27 +1042,52 @@ class RadDist(object):
                     bolo_channel = bolo_camera.bolometers[bolo_channel_indx]
                     for foil in bolo_channel.bolometer_camera:
                         slit_centre = foil.slit.centre_point
-                        ax.plot(slit_centre[0], slit_centre[1], slit_centre[2], 'ko')
+                        ax.plot(slit_centre[0], slit_centre[1], slit_centre[2], "ko")
                         origin, hit, _ = foil.trace_sightline()
-                        ax.plot(foil.centre_point[0], foil.centre_point[1], foil.centre_point[2], 'kx')
+                        ax.plot(
+                            foil.centre_point[0],
+                            foil.centre_point[1],
+                            foil.centre_point[2],
+                            "kx",
+                        )
                         if ColoredSightlines:
-                            colorNum =(self.boloCameras_powers[bolo_camera_indx][bolo_channel_indx]\
-                                    / boloPowersMax) * 5
+                            colorNum = (
+                                self.boloCameras_powers[bolo_camera_indx][
+                                    bolo_channel_indx
+                                ]
+                                / boloPowersMax
+                            ) * 5
                             color = plt.cm.Greys(colorNum)
                             if RemoveZeroSightlines:
                                 if colorNum > 0.005:
-                                    ax.plot([origin[0], hit[0]], [origin[1], hit[1]], [origin[2], hit[2]], c=color)
+                                    ax.plot(
+                                        [origin[0], hit[0]],
+                                        [origin[1], hit[1]],
+                                        [origin[2], hit[2]],
+                                        c=color,
+                                    )
                             else:
-                                ax.plot([origin[0], hit[0]], [origin[1], hit[1]], [origin[2], hit[2]], c=color)
+                                ax.plot(
+                                    [origin[0], hit[0]],
+                                    [origin[1], hit[1]],
+                                    [origin[2], hit[2]],
+                                    c=color,
+                                )
                         else:
-                            color='k'
-                            ax.plot([origin[0], hit[0]], [origin[1], hit[1]], [origin[2], hit[2]], c=color)
-        
+                            color = "k"
+                            ax.plot(
+                                [origin[0], hit[0]],
+                                [origin[1], hit[1]],
+                                [origin[2], hit[2]],
+                                c=color,
+                            )
+
         return fig
-    
-    def plot_unwrapped(self, TorDistFunc = None,\
-        SpotSize = 20, FromWhite = False, Resolution = 20, Alpha = 0.005):
-        
+
+    def plot_unwrapped(
+        self, TorDistFunc=None, SpotSize=20, FromWhite=False, Resolution=20, Alpha=0.005
+    ):
+
         # Makes a 3d plot of the RadDist, unwrapped. Toroidal distribution overlay
         # is only set up for helicals so far, and has not been tested.
 
@@ -764,111 +1095,132 @@ class RadDist(object):
         # giving the general radiation structure shape. Nevertheless, the internal radiation
         # structure is obscured by the external; such is 3d plotting. Adjust resolution and alpha for
         # better viewing.
-        
+
         if self.tokamak.mode != "Build":
-            print("The tokamak object of this RadDist is not in Build mode. To use this function,\
+            print(
+                "The tokamak object of this RadDist is not in Build mode. To use this function,\
                   Either pass Tokamak = [a tokamak object with mode == 'Build'], or pass\
-                  Tokamak = None and Mode = 'Build' to this RadDist")
+                  Tokamak = None and Mode = 'Build' to this RadDist"
+            )
             sys.exit(1)
-        
+
         majorRadius = self.tokamak.majorRadius
         minorRadius = self.tokamak.minorRadius
-        
-        xRes = math.ceil(Resolution*(2.0*minorRadius))
-        yRes = math.ceil(Resolution*(2.0*math.pi))
-        zRes = math.ceil(Resolution*(4.4*minorRadius))
-        
+
+        xRes = math.ceil(Resolution * (2.0 * minorRadius))
+        yRes = math.ceil(Resolution * (2.0 * math.pi))
+        zRes = math.ceil(Resolution * (4.4 * minorRadius))
+
         evalRs = np.linspace(majorRadius - minorRadius, majorRadius + minorRadius, xRes)
         evalPhis = np.linspace(-np.pi, np.pi, yRes)
-        evalZs = np.linspace(-2.2*minorRadius, 2.2*minorRadius, zRes)
-                        
+        evalZs = np.linspace(-2.2 * minorRadius, 2.2 * minorRadius, zRes)
+
         functionVals = []
         plotRs = []
         plotPhis = []
-        plotZs= []
-        
+        plotZs = []
+
         for evalR in evalRs:
             for evalZ in evalZs:
                 if self.tokamak.wallcurve.contains_points([(evalR, evalZ)]):
                     for evalPhi in evalPhis:
-                            evalX, evalY = RPhi_To_XY(evalR, evalPhi)
-                            
-                            if TorDistFunc is None:
-                                functionVal = self.evaluate_both_punc(evalX, evalY, evalZ)
-                            else:
-                                functionValFirst = self.evaluate_first_punc(evalX, evalY, evalZ)
-                                functionValSecond = self.evaluate_second_punc(evalX, evalY, evalZ)
-                                
-                                # Need to reconsider these for 0s vs injector locations...
-                                # First Puncture
-                                functionValFirst = functionValFirst *\
-                                        TorDistFunc(Phi0 = evalPhi)
-                                
-                                # Second Puncture
-                                if evalPhi >= self.tokamak.injectionPhiTor:
-                                    functionValSecond = functionValSecond *\
-                                        TorDistFunc(Phi0 = evalPhi - (2.0 * math.pi))
-                                else:
-                                    functionValSecond = functionValSecond *\
-                                        TorDistFunc(Phi0 = evalPhi + (2.0 * math.pi))
+                        evalX, evalY = RPhi_To_XY(evalR, evalPhi)
 
-                                functionVal = functionValFirst + functionValSecond
-                                
-                            plotRs.append(evalR)
-                            plotPhis.append(evalPhi)
-                            plotZs.append(evalZ)
-                            functionVals.append(functionVal)
-        
+                        if TorDistFunc is None:
+                            functionVal = self.evaluate_both_punc(evalX, evalY, evalZ)
+                        else:
+                            functionValFirst = self.evaluate_first_punc(
+                                evalX, evalY, evalZ
+                            )
+                            functionValSecond = self.evaluate_second_punc(
+                                evalX, evalY, evalZ
+                            )
+
+                            # Need to reconsider these for 0s vs injector locations...
+                            # First Puncture
+                            functionValFirst = functionValFirst * TorDistFunc(
+                                Phi0=evalPhi
+                            )
+
+                            # Second Puncture
+                            if evalPhi >= self.tokamak.injectionPhiTor:
+                                functionValSecond = functionValSecond * TorDistFunc(
+                                    Phi0=evalPhi - (2.0 * math.pi)
+                                )
+                            else:
+                                functionValSecond = functionValSecond * TorDistFunc(
+                                    Phi0=evalPhi + (2.0 * math.pi)
+                                )
+
+                            functionVal = functionValFirst + functionValSecond
+
+                        plotRs.append(evalR)
+                        plotPhis.append(evalPhi)
+                        plotZs.append(evalZ)
+                        functionVals.append(functionVal)
+
         # convert to RGB scale
         functionMax = np.max(functionVals) * 1e-1
         functionVals = [math.floor(255 * x / functionMax) for x in functionVals]
 
         # Delete points where radiated power is less than 1% of maximum
-        #negligible = np.argwhere(functionVals < (0.01 * functionMax))
-        negligible = np.argwhere(functionVals < np.float64(0.01*255.0))
-        functionVals = np.delete(functionVals, negligible) 
+        # negligible = np.argwhere(functionVals < (0.01 * functionMax))
+        negligible = np.argwhere(functionVals < np.float64(0.01 * 255.0))
+        functionVals = np.delete(functionVals, negligible)
         plotRs = np.delete(plotRs, negligible)
         plotPhis = np.delete(plotPhis, negligible)
         plotZs = np.delete(plotZs, negligible)
-        
+
         fig = plt.figure()
-        ax = plt.axes(projection = '3d')
+        ax = plt.axes(projection="3d")
         ax.set_xlim3d(majorRadius - minorRadius, majorRadius + minorRadius)
-        
-        if self.tokamak.tokamakName=="JET":
+
+        if self.tokamak.tokamakName == "JET":
             ax.set_zlim3d(-1.5 * minorRadius, 2.0 * minorRadius)
             phiLeft = self.tokamak.injectionPhiTor
             phiRight = self.tokamak.injectionPhiTor + (2.0 * np.pi)
-                    
-        elif self.tokamak.tokamakName=="SPARC":
+
+        elif self.tokamak.tokamakName == "SPARC":
             ax.set_zlim3d(-2.2 * minorRadius, 2.2 * minorRadius)
             phiLeft = self.tokamak.injectionPhiTor - (2.0 * np.pi)
             phiRight = self.tokamak.injectionPhiTor
-            
-        elif self.tokamak.tokamakName=="DIIID":
+
+        elif self.tokamak.tokamakName == "DIIID":
             ax.set_zlim3d(-2.2 * minorRadius, 2.2 * minorRadius)
             phiLeft = self.tokamak.injectionPhiTor - (2.0 * np.pi)
             phiRight = self.tokamak.injectionPhiTor
-            
+
         ax.set_ylim3d(phiLeft, phiRight)
         ax.view_init(elev=20.0, azim=200)
-        #ax.view_init(elev=20.0, azim=0)
-        
-        #Moves center of plot from phi = 0 to injector location
+        # ax.view_init(elev=20.0, azim=0)
+
+        # Moves center of plot from phi = 0 to injector location
         for distNum in range(len(plotPhis)):
             if plotPhis[distNum] < phiLeft:
                 plotPhis[distNum] = plotPhis[distNum] + (2.0 * np.pi)
             elif plotPhis[distNum] > phiRight:
                 plotPhis[distNum] = plotPhis[distNum] - (2.0 * np.pi)
-           
+
         # evaluate function scatter plot.
         if FromWhite == True:
-            ax.scatter(plotRs, plotPhis, plotZs, c = plt.cm.Purples(functionVals),
-                            s=SpotSize, alpha = Alpha)
+            ax.scatter(
+                plotRs,
+                plotPhis,
+                plotZs,
+                c=plt.cm.Purples(functionVals),
+                s=SpotSize,
+                alpha=Alpha,
+            )
         else:
-            ax.scatter(plotRs, plotPhis, plotZs, c = plt.cm.plasma(functionVals),
-                            s=SpotSize, alpha = Alpha)
-        
+            ax.scatter(
+                plotRs,
+                plotPhis,
+                plotZs,
+                c=plt.cm.plasma(functionVals),
+                s=SpotSize,
+                alpha=Alpha,
+            )
+
         # For plotting last closed flux surface
         """
         r, z = self.tokamakAMode.get_qsurface_contour(Qval="Separatrix")
@@ -877,15 +1229,15 @@ class RadDist(object):
         ax.plot3D(r,phiEdgeLeft,z, 'orange')
         ax.plot3D(r,phiEdgeRight,z, 'orange')
         """
-        
+
         # For plotting first wall contour
-        r = self.tokamak.wallcurve.vertices[:,0]
-        z = self.tokamak.wallcurve.vertices[:,1]
+        r = self.tokamak.wallcurve.vertices[:, 0]
+        z = self.tokamak.wallcurve.vertices[:, 1]
         phiEdgeLeft = [phiLeft] * len(r)
         phiEdgeRight = [phiRight] * len(r)
-        ax.plot3D(r,phiEdgeLeft,z, 'orange')
-        ax.plot3D(r,phiEdgeRight,z, 'orange')
-        
+        ax.plot3D(r, phiEdgeLeft, z, "orange")
+        ax.plot3D(r, phiEdgeRight, z, "orange")
+
         ax.set_xlabel("R")
         ax.set_ylabel("$\Phi$")
         ax.set_zlabel("Z")
@@ -895,76 +1247,92 @@ class RadDist(object):
         ax.set_yticks([])
         ax.set_zticks([])
         """
-        
+
         return fig
-    
-    def plot_crossSec(self, Phi = 0.0, TorDistFunc=None):
+
+    def plot_crossSec(self, Phi=0.0, TorDistFunc=None):
         # Makes a 2d plot of the RadDist at a given phi location. Phi is in radians.
         # Does not include any toroidal distribution overlay.
-        
+
         if self.tokamak.mode != "Build":
-            print("The tokamak object of this RadDist is not in Build mode. To use this function, "\
-                  + "Either pass Tokamak = [a tokamak object with mode == 'Build'], or pass "\
-                  + "Tokamak = None and Mode = 'Build' to this RadDist")
+            print(
+                "The tokamak object of this RadDist is not in Build mode. To use this function, "
+                + "Either pass Tokamak = [a tokamak object with mode == 'Build'], or pass "
+                + "Tokamak = None and Mode = 'Build' to this RadDist"
+            )
             sys.exit(1)
-        
+
         fig = plt.figure()
         ax = plt.axes()
 
         if TorDistFunc != None:
             firstPuncTorFactor = TorDistFunc(Phi0=Phi)
-            secondPuncClockwiseTorFactor = TorDistFunc(Phi0 = Phi-(2.0*np.pi))
-            secondPuncAntiClockwiseTorFactor = TorDistFunc(Phi0 = Phi+(2.0*np.pi))
-        
+            secondPuncClockwiseTorFactor = TorDistFunc(Phi0=Phi - (2.0 * np.pi))
+            secondPuncAntiClockwiseTorFactor = TorDistFunc(Phi0=Phi + (2.0 * np.pi))
+
         # make 2d grids of r, z, and emissivity values (all start at 0)
-        r = np.linspace(self.tokamak.majorRadius-self.tokamak.minorRadius,\
-                        self.tokamak.majorRadius+self.tokamak.minorRadius, num=50)
-        z = np.linspace(-2.5*self.tokamak.minorRadius,\
-                        2.5*self.tokamak.minorRadius, num=90)
-        rgrid,zgrid = np.meshgrid(r,z)
-        emis = rgrid*0.
-        
+        r = np.linspace(
+            self.tokamak.majorRadius - self.tokamak.minorRadius,
+            self.tokamak.majorRadius + self.tokamak.minorRadius,
+            num=50,
+        )
+        z = np.linspace(
+            -2.5 * self.tokamak.minorRadius, 2.5 * self.tokamak.minorRadius, num=90
+        )
+        rgrid, zgrid = np.meshgrid(r, z)
+        emis = rgrid * 0.0
+
         # take a few phi phi values about the desired phi value
-        for phi in np.linspace(Phi-0.01, Phi+0.01, 4):
+        for phi in np.linspace(Phi - 0.01, Phi + 0.01, 4):
             # convert to x and y
-            xgrid, ygrid, = RPhi_To_XY(rgrid, phi)          
-            
-            for i,j in np.ndindex(xgrid.shape):
+            (
+                xgrid,
+                ygrid,
+            ) = RPhi_To_XY(rgrid, phi)
+
+            for i, j in np.ndindex(xgrid.shape):
                 # add emissivity at each point to its point on the emis grid
-                x = xgrid[i,j]
-                y = ygrid[i,j]
-                z1 = zgrid[i,j]
-                
+                x = xgrid[i, j]
+                y = ygrid[i, j]
+                z1 = zgrid[i, j]
+
                 if TorDistFunc == None:
-                    emis[i,j] += self.evaluate_both_punc(x,y,z1)
+                    emis[i, j] += self.evaluate_both_punc(x, y, z1)
                 else:
-                    emis[i,j] += self.evaluate_first_punc(x,y,z1) * firstPuncTorFactor
-                    
+                    emis[i, j] += (
+                        self.evaluate_first_punc(x, y, z1) * firstPuncTorFactor
+                    )
+
                     if phi >= self.tokamak.injectionPhiTor:
-                        emis[i,j] += self.evaluate_second_punc(x,y,z1) *\
-                            secondPuncClockwiseTorFactor
+                        emis[i, j] += (
+                            self.evaluate_second_punc(x, y, z1)
+                            * secondPuncClockwiseTorFactor
+                        )
                     else:
-                        emis[i,j] += self.evaluate_second_punc(x,y,z1) *\
-                            secondPuncAntiClockwiseTorFactor
+                        emis[i, j] += (
+                            self.evaluate_second_punc(x, y, z1)
+                            * secondPuncAntiClockwiseTorFactor
+                        )
 
         # make 2d plot
-        ax.contourf(r,z, emis, levels=20, cmap="Blues")
-        
+        ax.contourf(r, z, emis, levels=20, cmap="Blues")
+
         # For plotting first wall contour
-        r = self.tokamak.wallcurve.vertices[:,0]
-        z = self.tokamak.wallcurve.vertices[:,1]
-        ax.plot(r,z, 'orange')
-        
+        r = self.tokamak.wallcurve.vertices[:, 0]
+        z = self.tokamak.wallcurve.vertices[:, 1]
+        ax.plot(r, z, "orange")
+
         ax.set_title("Phi = Injector")
-        ax.set_ylabel('Z [m]')
-        ax.set_xlabel('R [m]')
-        
-        ax.set_aspect('equal')
-        
+        ax.set_ylabel("Z [m]")
+        ax.set_xlabel("R [m]")
+
+        ax.set_aspect("equal")
+
         return fig
-    
-    def observe_local_intensity(self, ApCenterPoint = [2.18, 0.68, 0.0],\
-                                FoilRotVec = [0.0, -np.pi/4.0, np.pi]):
+
+    def observe_local_intensity(
+        self, ApCenterPoint=[2.18, 0.68, 0.0], FoilRotVec=[0.0, -np.pi / 4.0, np.pi]
+    ):
         # aperature center point is r,z,phi
         # foil rotation vector is the direction the "foil" is pointing in,
         # the normal vector to the surface where the intensity is observed.
@@ -973,9 +1341,11 @@ class RadDist(object):
         # third angle is angle in x-y plane starting from outwards
 
         if self.tokamak.mode != "Build":
-            print("The tokamak object of this RadDist is not in Build mode. To use this function,\
+            print(
+                "The tokamak object of this RadDist is not in Build mode. To use this function,\
                   Either pass Tokamak = [a tokamak object with mode == 'Build'], or pass Tokamak = None and Mode = 'Build'\
-                  to this RadDist")
+                  to this RadDist"
+            )
             sys.exit(11)
 
         # set random seed to always be the same so that the result is not different every run
@@ -983,54 +1353,74 @@ class RadDist(object):
         # this is a known issue...
         # https://github.com/ray-project/ray/issues/10145
         raysectseed(self.randSeed)
-            
+
         tempworld = deepcopy(self.tokamak.world)
-        sensor = Synth_Brightness_Observer(World=tempworld,\
-                ApCenterPoint = ApCenterPoint,\
-                FoilRotVec = FoilRotVec,\
-                IndicatorLights=False)
-        
+        sensor = Synth_Brightness_Observer(
+            World=tempworld,
+            ApCenterPoint=ApCenterPoint,
+            FoilRotVec=FoilRotVec,
+            IndicatorLights=False,
+        )
+
         for foil in sensor.bolometer_camera.foil_detectors:
             # the following line sets the number of rays to trace at once in parallel. Heimdall can apparently do 16.
             foil.render_engine.processes = 16
             # The following line sets the resolution of the sightline area viewed by each bolometer. Jack Lovell says this
             # number is reasonable.
-            foil.pixel_samples = 1e6 # 1e5
-        
+            foil.pixel_samples = 1e6  # 1e5
+
         # The following ines define an emitting volume that the RadDist will evaluate functions are embedded in.
         # The parameters are set to encompass to entirety of the tokamak (this setup is for JET and smaller), and the -2.5 is to shift the
         # volume so that it is vertically centered at  z = 0.
         # the first line defines the shape, the second makes it an emitting volume, the third embeds it in the world of the tokamak in question
         emitter = Cylinder(radius=5, height=5, transform=translate(0, 0, -2.5))
         emitter.parent = tempworld
-        
-        # Observe first punctures
-        emitter.material = VolumeTransform(RadiationFunction(\
-            self.evaluate_first_punc_cherab), emitter.transform.inverse())
-        
-        sensor_power_firstpunc = sensor.bolometer_camera.observe()
-        
-        # Observe second punctures
-        emitter.material = VolumeTransform(RadiationFunction(\
-            self.evaluate_second_punc_cherab), emitter.transform.inverse())
-        
-        sensor_power_secondpunc = sensor.bolometer_camera.observe()
-        
-        #print("Intensity Sensor Power 1st Punc = " + str(sensor_power_firstpunc) + " [W]")
-        #print("Intensity Sensor Power 2nd Punc = " + str(sensor_power_secondpunc) + " [W]")
 
-        return(sensor_power_firstpunc[0] + sensor_power_secondpunc[0])
-        
+        # Observe first punctures
+        emitter.material = VolumeTransform(
+            RadiationFunction(self.evaluate_first_punc_cherab),
+            emitter.transform.inverse(),
+        )
+
+        sensor_power_firstpunc = sensor.bolometer_camera.observe()
+
+        # Observe second punctures
+        emitter.material = VolumeTransform(
+            RadiationFunction(self.evaluate_second_punc_cherab),
+            emitter.transform.inverse(),
+        )
+
+        sensor_power_secondpunc = sensor.bolometer_camera.observe()
+
+        # print("Intensity Sensor Power 1st Punc = " + str(sensor_power_firstpunc) + " [W]")
+        # print("Intensity Sensor Power 2nd Punc = " + str(sensor_power_secondpunc) + " [W]")
+
+        return sensor_power_firstpunc[0] + sensor_power_secondpunc[0]
+
+
 class Toroidal(RadDist):
     # this class has a gaussian distribution about a flat toroidal ring
-    def __init__(self, NumBins = 18, Tokamak = None,\
-                 Mode = "Analysis", LoadFileName = None,\
-                 StartR = None, StartZ = 0.0, PolSigma = 0.15,\
-                 SaveFileFolder=None, TorSegmented=False):
-        super(Toroidal, self).__init__(NumBins = NumBins,\
-                 NumPuncs = 1, Tokamak = Tokamak,\
-                 Mode = Mode, LoadFileName = LoadFileName,\
-                 SaveFileFolder=SaveFileFolder, TorSegmented=TorSegmented)
+    def __init__(
+        self,
+        NumBins=18,
+        Tokamak=None,
+        Mode="Analysis",
+        LoadFileName=None,
+        StartR=None,
+        StartZ=0.0,
+        PolSigma=0.15,
+        SaveFileFolder=None,
+        TorSegmented=False,
+    ):
+        super(Toroidal, self).__init__(
+            NumBins=NumBins,
+            NumPuncs=1,
+            Tokamak=Tokamak,
+            Mode=Mode,
+            LoadFileName=LoadFileName,
+            SaveFileFolder=SaveFileFolder,
+            TorSegmented=TorSegmented,
+        )
         if LoadFileName == None:
             if StartR == None:
                 self.startR = self.tokamak.majorRadius
@@ -1044,59 +1434,85 @@ class Toroidal(RadDist):
             self.startR = properties["startR"]
             self.startZ = properties["startZ"]
             self.polSigma = properties["polSigma"]
-        
+
         self.distType = "Toroidal"
-        
+
         if Mode == "Build":
             self.make_build_mode()
-        
+
     def make_build_mode(self):
         # toroidals need no additions for build mode
         pass
-        
-    def evaluate(self, x,y,z, EvalFirstPunc, EvalSecondPunc):
-        
+
+    def evaluate(self, x, y, z, EvalFirstPunc, EvalSecondPunc):
+
         # first we need to convert from x,y,z to R,Z,phi
         Z = z
-        R, phi0 = XY_To_RPhi(x,y)
-        
+        R, phi0 = XY_To_RPhi(x, y)
+
         if EvalFirstPunc:
-            # bivariate normal distribution in poloidal plane. 
-            # integrated over dR and dZ this function returns 1. 
-            localEmis = (1 / (2 * np.pi * self.polSigma**2)
-                * math.exp(-0.5 * ((R - self.startR)**2 + (Z - self.startZ)**2) / self.polSigma**2))
-            
+            # bivariate normal distribution in poloidal plane.
+            # integrated over dR and dZ this function returns 1.
+            localEmis = (
+                1
+                / (2 * np.pi * self.polSigma**2)
+                * math.exp(
+                    -0.5
+                    * ((R - self.startR) ** 2 + (Z - self.startZ) ** 2)
+                    / self.polSigma**2
+                )
+            )
+
             return localEmis
-            
+
         if EvalSecondPunc:
-            
+
             return 0.0
-        
-    def save_RadDist(self, RoundDec = 2):
-        #[saves radiation distribution to a file]
-        
+
+    def save_RadDist(self, RoundDec=2):
+        # [saves radiation distribution to a file]
+
         properties = self.__dict__
         properties = self.prepare_for_JSON(properties)
-        
-        saveFileName = join(self.saveFileFolder,"toroidal_pSig_") + str(round(self.polSigma, RoundDec)).replace('.', '_')\
-        + "_R_" + str(round(self.startR, RoundDec)).replace('.', '_')\
-        + "_Z_" + str(round(self.startZ, RoundDec)).replace('.', '_').replace('-', 'neg')\
-        + ".txt"
-          
-        with open(saveFileName, 'w') as save_file:
-             save_file.write(json.dumps(properties))
-             
+
+        saveFileName = (
+            join(self.saveFileFolder, "toroidal_pSig_")
+            + str(round(self.polSigma, RoundDec)).replace(".", "_")
+            + "_R_"
+            + str(round(self.startR, RoundDec)).replace(".", "_")
+            + "_Z_"
+            + str(round(self.startZ, RoundDec)).replace(".", "_").replace("-", "neg")
+            + ".txt"
+        )
+
+        with open(saveFileName, "w") as save_file:
+            save_file.write(json.dumps(properties))
+
+
 class ReflectedToroidal(RadDist):
     # this class has a gaussian distribution about a flat toroidal ring
     # plus a reflection of that gaussian over the xy plane
-    def __init__(self, NumBins = 18, Tokamak = None,\
-                 Mode = "Analysis", LoadFileName = None,\
-                 StartR = None, StartZ = 0.0, PolSigma = 0.15,\
-                 SaveFileFolder=None, TorSegmented=False):
-        super(ReflectedToroidal, self).__init__(NumBins = NumBins,\
-                 NumPuncs = 1, Tokamak = Tokamak,\
-                 Mode = Mode, LoadFileName = LoadFileName,\
-                 SaveFileFolder=SaveFileFolder, TorSegmented=TorSegmented)
+    def __init__(
+        self,
+        NumBins=18,
+        Tokamak=None,
+        Mode="Analysis",
+        LoadFileName=None,
+        StartR=None,
+        StartZ=0.0,
+        PolSigma=0.15,
+        SaveFileFolder=None,
+        TorSegmented=False,
+    ):
+        super(ReflectedToroidal, self).__init__(
+            NumBins=NumBins,
+            NumPuncs=1,
+            Tokamak=Tokamak,
+            Mode=Mode,
+            LoadFileName=LoadFileName,
+            SaveFileFolder=SaveFileFolder,
+            TorSegmented=TorSegmented,
+        )
         if LoadFileName == None:
             if StartR == None:
                 self.startR = self.tokamak.majorRadius
@@ -1110,65 +1526,98 @@ class ReflectedToroidal(RadDist):
             self.startR = properties["startR"]
             self.startZ = properties["startZ"]
             self.polSigma = properties["polSigma"]
-        
+
         self.distType = "ReflectedToroidal"
-        
+
         if Mode == "Build":
             self.make_build_mode()
-        
+
     def make_build_mode(self):
         # toroidals need no additions for build mode
         pass
-        
-    def evaluate(self, x,y,z, EvalFirstPunc, EvalSecondPunc):
-        
+
+    def evaluate(self, x, y, z, EvalFirstPunc, EvalSecondPunc):
+
         # first we need to convert from x,y,z to R,Z,phi
         Z = z
-        R, phi0 = XY_To_RPhi(x,y)
-        
+        R, phi0 = XY_To_RPhi(x, y)
+
         if EvalFirstPunc:
-            # bivariate normal distribution in poloidal plane. 
-            # integrated over dR and dZ this function returns 1. 
-            localEmis1 = (1 / (2 * np.pi * self.polSigma**2)
-                * math.exp(-0.5 * ((R - self.startR)**2 + (Z - self.startZ)**2) / self.polSigma**2))
-            
+            # bivariate normal distribution in poloidal plane.
+            # integrated over dR and dZ this function returns 1.
+            localEmis1 = (
+                1
+                / (2 * np.pi * self.polSigma**2)
+                * math.exp(
+                    -0.5
+                    * ((R - self.startR) ** 2 + (Z - self.startZ) ** 2)
+                    / self.polSigma**2
+                )
+            )
+
             # add a second gaussian spot refected about xy plane
-            localEmis2 = (1 / (2 * np.pi * self.polSigma**2)
-                * math.exp(-0.5 * ((R - self.startR)**2 + (Z + self.startZ)**2) / self.polSigma**2))
+            localEmis2 = (
+                1
+                / (2 * np.pi * self.polSigma**2)
+                * math.exp(
+                    -0.5
+                    * ((R - self.startR) ** 2 + (Z + self.startZ) ** 2)
+                    / self.polSigma**2
+                )
+            )
 
             localEmis = localEmis1 + localEmis2
             return localEmis
-            
+
         if EvalSecondPunc:
-            
+
             return 0.0
-        
-    def save_RadDist(self, RoundDec = 2):
-        #[saves radiation distribution to a file]
-        
+
+    def save_RadDist(self, RoundDec=2):
+        # [saves radiation distribution to a file]
+
         properties = self.__dict__
         properties = self.prepare_for_JSON(properties)
-        
-        saveFileName = join(self.saveFileFolder,"reflectedtoroidal_pSig_") + str(round(self.polSigma, RoundDec)).replace('.', '_')\
-        + "_R_" + str(round(self.startR, RoundDec)).replace('.', '_')\
-        + "_Z_" + str(round(self.startZ, RoundDec)).replace('.', '_').replace('-', 'neg')\
-        + ".txt"
-          
-        with open(saveFileName, 'w') as save_file:
-             save_file.write(json.dumps(properties))
+
+        saveFileName = (
+            join(self.saveFileFolder, "reflectedtoroidal_pSig_")
+            + str(round(self.polSigma, RoundDec)).replace(".", "_")
+            + "_R_"
+            + str(round(self.startR, RoundDec)).replace(".", "_")
+            + "_Z_"
+            + str(round(self.startZ, RoundDec)).replace(".", "_").replace("-", "neg")
+            + ".txt"
+        )
+
+        with open(saveFileName, "w") as save_file:
+            save_file.write(json.dumps(properties))
+
 
 class TiltedReflectedToroidal(RadDist):
     # this class has a gaussian distribution about a flat toroidal ring
     # plus a reflection of that gaussian over the xy plane
-    def __init__(self, NumBins = 18, Tokamak = None,\
-                 Mode = "Analysis", LoadFileName = None,\
-                 StartR = None, StartZ = 0.0, PolSigma = 0.15,\
-                 Elongation = 1.0,\
-                 SaveFileFolder=None, TorSegmented=False):
-        super(TiltedReflectedToroidal, self).__init__(NumBins = NumBins,\
-                 NumPuncs = 1, Tokamak = Tokamak,\
-                 Mode = Mode, LoadFileName = LoadFileName,\
-                 SaveFileFolder=SaveFileFolder, TorSegmented=TorSegmented)
+    def __init__(
+        self,
+        NumBins=18,
+        Tokamak=None,
+        Mode="Analysis",
+        LoadFileName=None,
+        StartR=None,
+        StartZ=0.0,
+        PolSigma=0.15,
+        Elongation=1.0,
+        SaveFileFolder=None,
+        TorSegmented=False,
+    ):
+        super(TiltedReflectedToroidal, self).__init__(
+            NumBins=NumBins,
+            NumPuncs=1,
+            Tokamak=Tokamak,
+            Mode=Mode,
+            LoadFileName=LoadFileName,
+            SaveFileFolder=SaveFileFolder,
+            TorSegmented=TorSegmented,
+        )
         if LoadFileName == None:
             if StartR == None:
                 self.startR = self.tokamak.majorRadius
@@ -1184,88 +1633,127 @@ class TiltedReflectedToroidal(RadDist):
             self.startZ = properties["startZ"]
             self.polSigma = properties["polSigma"]
             self.elongation = properties["elongation"]
-        
+
         self.distType = "TiltedReflectedToroidal"
-        
+
         if Mode == "Build":
             self.make_build_mode()
-        
+
     def make_build_mode(self):
-        vertExtendParam = 3.0 # for vertical extension of plasma... hardcoded for now
+        vertExtendParam = 3.0  # for vertical extension of plasma... hardcoded for now
 
         # first we need to decompose (R,Z) in terms of parallel/perpendicular
         # to tilt direction. Approximated as the perpendicular direction
         # to the vector from (major radius, 0) to (startR, startZ)
         # "cent0" = (major radius, 0), "cent1" = (startR, startZ), "point" = (R,Z)
-        cent0ToCent1Vec = [self.startR - self.tokamak.majorRadius,self.startZ]
+        cent0ToCent1Vec = [self.startR - self.tokamak.majorRadius, self.startZ]
         cent0ToCent1Vec[1] = cent0ToCent1Vec[1] / vertExtendParam
-        cent0ToCent1VecMag = math.sqrt(cent0ToCent1Vec[0]**2 + cent0ToCent1Vec[1]**2)
-        self.cent0ToCent1VecNormed = [x/cent0ToCent1VecMag\
-                            for x in cent0ToCent1Vec]
-        self.perpVecNormed = [-self.cent0ToCent1VecNormed[1], self.cent0ToCent1VecNormed[0]]      
-        
-    def evaluate(self, x,y,z, EvalFirstPunc, EvalSecondPunc):
-        
+        cent0ToCent1VecMag = math.sqrt(
+            cent0ToCent1Vec[0] ** 2 + cent0ToCent1Vec[1] ** 2
+        )
+        self.cent0ToCent1VecNormed = [x / cent0ToCent1VecMag for x in cent0ToCent1Vec]
+        self.perpVecNormed = [
+            -self.cent0ToCent1VecNormed[1],
+            self.cent0ToCent1VecNormed[0],
+        ]
+
+    def evaluate(self, x, y, z, EvalFirstPunc, EvalSecondPunc):
+
         # first we need to convert from x,y,z to R,Z,phi
         Z = z
-        R, phi0 = XY_To_RPhi(x,y)
-        
+        R, phi0 = XY_To_RPhi(x, y)
+
         if EvalFirstPunc:
             # first (tilted) gaussian spot
             cent1ToPointVec = [R - self.startR, Z - self.startZ]
-            paralleldist = cent1ToPointVec[0] * self.cent0ToCent1VecNormed[0] +\
-                cent1ToPointVec[1] * self.cent0ToCent1VecNormed[1]
-            perpdist = cent1ToPointVec[0] * self.perpVecNormed[0] +\
-                cent1ToPointVec[1] * self.perpVecNormed[1]
-            
-            localEmis1 = ((1.0 / (2.0 * np.pi * self.elongation * (self.polSigma**2)))\
-                * math.exp(-0.5 * (perpdist**2) / (self.polSigma*self.elongation)**2)\
-                * math.exp(-0.5 * (paralleldist**2) / self.polSigma**2))
-            
+            paralleldist = (
+                cent1ToPointVec[0] * self.cent0ToCent1VecNormed[0]
+                + cent1ToPointVec[1] * self.cent0ToCent1VecNormed[1]
+            )
+            perpdist = (
+                cent1ToPointVec[0] * self.perpVecNormed[0]
+                + cent1ToPointVec[1] * self.perpVecNormed[1]
+            )
+
+            localEmis1 = (
+                (1.0 / (2.0 * np.pi * self.elongation * (self.polSigma**2)))
+                * math.exp(
+                    -0.5 * (perpdist**2) / (self.polSigma * self.elongation) ** 2
+                )
+                * math.exp(-0.5 * (paralleldist**2) / self.polSigma**2)
+            )
+
             # second gaussian spot, reflected over xy plane
             cent1ToPointVec = [R - self.startR, Z + self.startZ]
-            paralleldist = cent1ToPointVec[0] * self.cent0ToCent1VecNormed[0] +\
-                cent1ToPointVec[1] * (-1.0* self.cent0ToCent1VecNormed[1])
-            perpdist = cent1ToPointVec[0] * self.perpVecNormed[0] +\
-                cent1ToPointVec[1] * (-1.0 * self.perpVecNormed[1])
-            
-            localEmis2 = ((1.0 / (2.0 * np.pi * self.elongation * (self.polSigma**2)))\
-                * math.exp(-0.5 * (perpdist**2) / (self.polSigma*self.elongation)**2)\
-                * math.exp(-0.5 * (paralleldist**2) / self.polSigma**2))
+            paralleldist = cent1ToPointVec[0] * self.cent0ToCent1VecNormed[
+                0
+            ] + cent1ToPointVec[1] * (-1.0 * self.cent0ToCent1VecNormed[1])
+            perpdist = cent1ToPointVec[0] * self.perpVecNormed[0] + cent1ToPointVec[
+                1
+            ] * (-1.0 * self.perpVecNormed[1])
+
+            localEmis2 = (
+                (1.0 / (2.0 * np.pi * self.elongation * (self.polSigma**2)))
+                * math.exp(
+                    -0.5 * (perpdist**2) / (self.polSigma * self.elongation) ** 2
+                )
+                * math.exp(-0.5 * (paralleldist**2) / self.polSigma**2)
+            )
 
             localEmis = localEmis1 + localEmis2
             return localEmis
-            
+
         if EvalSecondPunc:
-            
+
             return 0.0
-        
-    def save_RadDist(self, RoundDec = 2):
-        #[saves radiation distribution to a file]
-        
+
+    def save_RadDist(self, RoundDec=2):
+        # [saves radiation distribution to a file]
+
         properties = self.__dict__
         properties = self.prepare_for_JSON(properties)
-        
-        saveFileName = join(self.saveFileFolder,"tiltedreflectedtoroidal_pSig_") + str(round(self.polSigma, RoundDec)).replace('.', '_')\
-        + "_R_" + str(round(self.startR, RoundDec)).replace('.', '_')\
-        + "_Z_" + str(round(self.startZ, RoundDec)).replace('.', '_').replace('-', 'neg')\
-        + "_e_" + str(self.elongation).replace('.', '_')\
-        + ".txt"
-          
-        with open(saveFileName, 'w') as save_file:
-             save_file.write(json.dumps(properties))
+
+        saveFileName = (
+            join(self.saveFileFolder, "tiltedreflectedtoroidal_pSig_")
+            + str(round(self.polSigma, RoundDec)).replace(".", "_")
+            + "_R_"
+            + str(round(self.startR, RoundDec)).replace(".", "_")
+            + "_Z_"
+            + str(round(self.startZ, RoundDec)).replace(".", "_").replace("-", "neg")
+            + "_e_"
+            + str(self.elongation).replace(".", "_")
+            + ".txt"
+        )
+
+        with open(saveFileName, "w") as save_file:
+            save_file.write(json.dumps(properties))
+
 
 class ElongatedRing(RadDist):
     # this class has a bivariate gaussian distribution about a circle, with different
     # gaussian widths in r and z
-    def __init__(self, NumBins = 18, Tokamak = None,\
-                 Mode = "Analysis", LoadFileName = None,\
-                 StartR = None, StartZ = 0.0, PolSigma = 0.15,\
-                 Elongation=1.0, SaveFileFolder=None, TorSegmented=False):
-        super(ElongatedRing, self).__init__(NumBins = NumBins,\
-                 NumPuncs = 1, Tokamak = Tokamak,\
-                 Mode = Mode, LoadFileName = LoadFileName,\
-                 SaveFileFolder=SaveFileFolder, TorSegmented=TorSegmented)
+    def __init__(
+        self,
+        NumBins=18,
+        Tokamak=None,
+        Mode="Analysis",
+        LoadFileName=None,
+        StartR=None,
+        StartZ=0.0,
+        PolSigma=0.15,
+        Elongation=1.0,
+        SaveFileFolder=None,
+        TorSegmented=False,
+    ):
+        super(ElongatedRing, self).__init__(
+            NumBins=NumBins,
+            NumPuncs=1,
+            Tokamak=Tokamak,
+            Mode=Mode,
+            LoadFileName=LoadFileName,
+            SaveFileFolder=SaveFileFolder,
+            TorSegmented=TorSegmented,
+        )
         if LoadFileName == None:
             if StartR == None:
                 self.startR = self.tokamak.majorRadius
@@ -1281,61 +1769,89 @@ class ElongatedRing(RadDist):
             self.startZ = properties["startZ"]
             self.polSigma = properties["polSigma"]
             self.elongation = properties["elongation"]
-        
+
         self.distType = "ElongatedRing"
-        
+
         if Mode == "Build":
             self.make_build_mode()
-        
+
     def make_build_mode(self):
         # toroidally symmetric radDists need no additions for build mode
         pass
-        
-    def evaluate(self, x,y,z, EvalFirstPunc, EvalSecondPunc):
-        
+
+    def evaluate(self, x, y, z, EvalFirstPunc, EvalSecondPunc):
+
         # first we need to convert from x,y,z to R,Z,phi
         Z = z
-        R, phi0 = XY_To_RPhi(x,y)
-        
+        R, phi0 = XY_To_RPhi(x, y)
+
         if EvalFirstPunc:
-            # bivariate normal distribution in poloidal plane. 
+            # bivariate normal distribution in poloidal plane.
             # integrated over dR and dZ this function returns 1. I think.
-            localEmis = ((1.0 / (2.0 * np.pi * self.elongation * self.polSigma**2))\
-                * math.exp(-0.5 * ((R - self.startR)**2) / self.polSigma**2)\
-                * math.exp(-0.5 * ((Z - self.startZ)**2) / (self.polSigma*self.elongation)**2))
-            
+            localEmis = (
+                (1.0 / (2.0 * np.pi * self.elongation * self.polSigma**2))
+                * math.exp(-0.5 * ((R - self.startR) ** 2) / self.polSigma**2)
+                * math.exp(
+                    -0.5
+                    * ((Z - self.startZ) ** 2)
+                    / (self.polSigma * self.elongation) ** 2
+                )
+            )
+
             return localEmis
-            
+
         if EvalSecondPunc:
-            
+
             return 0.0
-        
-    def save_RadDist(self, RoundDec = 2):
-        #[saves radiation distribution to a file]
-        
+
+    def save_RadDist(self, RoundDec=2):
+        # [saves radiation distribution to a file]
+
         properties = self.__dict__
         properties = self.prepare_for_JSON(properties)
-        
-        saveFileName = join(self.saveFileFolder,"eRing_pSig_") + str(round(self.polSigma, RoundDec)).replace('.', '_')\
-        + "_elong_" + str(round(self.elongation, RoundDec)).replace('.', '_')\
-        + "_R_" + str(round(self.startR, RoundDec)).replace('.', '_')\
-        + "_Z_" + str(round(self.startZ, RoundDec)).replace('.', '_').replace('-', 'neg')\
-        + ".txt"
-          
-        with open(saveFileName, 'w') as save_file:
-             save_file.write(json.dumps(properties))
-                 
+
+        saveFileName = (
+            join(self.saveFileFolder, "eRing_pSig_")
+            + str(round(self.polSigma, RoundDec)).replace(".", "_")
+            + "_elong_"
+            + str(round(self.elongation, RoundDec)).replace(".", "_")
+            + "_R_"
+            + str(round(self.startR, RoundDec)).replace(".", "_")
+            + "_Z_"
+            + str(round(self.startZ, RoundDec)).replace(".", "_").replace("-", "neg")
+            + ".txt"
+        )
+
+        with open(saveFileName, "w") as save_file:
+            save_file.write(json.dumps(properties))
+
+
 class Helical(RadDist):
     # this class will have specifically helical radiation distributions
-    def __init__(self, NumBins = 18, Tokamak = None,\
-                 Mode = "Analysis", LoadFileName = None,\
-                 StartR = 2.96, StartZ = 0.0, PolSigma = 0.15,\
-                 ShotNumber = None, Time=0, SaveFileFolder=None, TorSegmented=False):
-        super(Helical, self).__init__(NumBins = NumBins, NumPuncs = 2,\
-                 Tokamak = Tokamak, Mode = Mode,\
-                 LoadFileName = LoadFileName,\
-                 SaveFileFolder=SaveFileFolder, TorSegmented=TorSegmented)
-    
+    def __init__(
+        self,
+        NumBins=18,
+        Tokamak=None,
+        Mode="Analysis",
+        LoadFileName=None,
+        StartR=2.96,
+        StartZ=0.0,
+        PolSigma=0.15,
+        ShotNumber=None,
+        Time=0,
+        SaveFileFolder=None,
+        TorSegmented=False,
+    ):
+        super(Helical, self).__init__(
+            NumBins=NumBins,
+            NumPuncs=2,
+            Tokamak=Tokamak,
+            Mode=Mode,
+            LoadFileName=LoadFileName,
+            SaveFileFolder=SaveFileFolder,
+            TorSegmented=TorSegmented,
+        )
+
         if LoadFileName == None:
             self.startR = StartR
             self.startZ = StartZ
@@ -1350,84 +1866,160 @@ class Helical(RadDist):
             self.shotnumber = properties["shotnumber"]
             self.polSigma = properties["polSigma"]
             self.time = properties["time"]
-            
+
         self.distType = "Helical"
-        
+
         if Mode == "Build":
             self.make_build_mode()
-            
+
     def make_build_mode(self):
-        self.tokamak.set_fieldline(StartR = self.startR, StartZ = self.startZ,\
-            StartPhi = self.tokamak.injectionPhiTor, FlineShotNumber = self.shotnumber)
-    
-    def evaluate(self, x,y,z, EvalFirstPunc, EvalSecondPunc):
+        self.tokamak.set_fieldline(
+            StartR=self.startR,
+            StartZ=self.startZ,
+            StartPhi=self.tokamak.injectionPhiTor,
+            FlineShotNumber=self.shotnumber,
+        )
+
+    def evaluate_fast(self, R, phi, z, EvalFirstPunc, EvalSecondPunc):
+        # Return the emissivity (W/m^3/rad) at the point (x,y,z) according to this
+        # instantiation of Emis3D. This function works only with scalar values of x, y and z.
+        Z = z
+        phi0 = phi
+
+        # readjust range of phi to center on injector location
+        loc_ = phi0 <= (self.tokamak.injectionPhiTor - np.pi)
+        phi0[loc_] = phi0[loc_] + 2.0 * np.pi
+
+        localEmis0 = 0.0
+        localEmis1 = 0.0
+        if EvalFirstPunc:
+            # next we need the R,Z position of our helical structure at this phi
+            flR, flZ = self.tokamak.find_RZ_Fline_fast(Phi=phi0)
+
+            # bivariate normal distribution in poloidal plane.
+            # integrated over dR and dZ this function returns 1.
+            localEmis0 = (
+                1
+                / (2 * np.pi * self.polSigma**2)
+                * np.exp(-0.5 * ((R - flR) ** 2 + (Z - flZ) ** 2) / self.polSigma**2)
+            )
+
+        if EvalSecondPunc:
+            # this is the setup for 2 times around
+            loc_ = phi0 >= self.tokamak.injectionPhiTor
+            phi0[loc_] = phi0[loc_] - 2.0 * np.pi
+            phi0[np.invert(loc_)] = phi0[np.invert(loc_)] + 2.0 * np.pi
+
+            # next we need the R,Z position of our helical structure at this phi
+            flR, flZ = self.tokamak.find_RZ_Fline_fast(Phi=phi0)
+
+            # bivariate normal distribution in poloidal plane.
+            # integrated over dR and dZ this function returns 1.
+            localEmis1 = (
+                1
+                / (2 * np.pi * self.polSigma**2)
+                * np.exp(-0.5 * ((R - flR) ** 2 + (Z - flZ) ** 2) / self.polSigma**2)
+            )
+
+        return localEmis0 + localEmis1
+
+    def evaluate(self, x, y, z, EvalFirstPunc, EvalSecondPunc):
         # Return the emissivity (W/m^3/rad) at the point (x,y,z) according to this
         # instantiation of Emis3D. This function works only with scalar values of x, y and z.
 
         # first we need to convert from x,y,z to R,Z,phi
         Z = z
-        R, phi0 = XY_To_RPhi(x,y)
+        R, phi0 = XY_To_RPhi(x, y)
         # readjust range of phi to center on injector location
         if phi0 <= self.tokamak.injectionPhiTor - np.pi:
-            phi0 = phi0 + 2.*np.pi
+            phi0 = phi0 + 2.0 * np.pi
 
-        localEmis0 = 0.
-        localEmis1 = 0.
+        localEmis0 = 0.0
+        localEmis1 = 0.0
         if EvalFirstPunc:
             # next we need the R,Z position of our helical structure at this phi
             flR, flZ = self.tokamak.find_RZ_Fline(Phi=phi0)
 
-            # bivariate normal distribution in poloidal plane. 
-            # integrated over dR and dZ this function returns 1. 
-            localEmis0 = (1 / (2 * np.pi * self.polSigma**2)
-                         * math.exp(-0.5 * ((R - flR)**2 + (Z - flZ)**2) / self.polSigma**2))
+            # bivariate normal distribution in poloidal plane.
+            # integrated over dR and dZ this function returns 1.
+            localEmis0 = (
+                1
+                / (2 * np.pi * self.polSigma**2)
+                * math.exp(-0.5 * ((R - flR) ** 2 + (Z - flZ) ** 2) / self.polSigma**2)
+            )
 
         if EvalSecondPunc:
             # this is the setup for 2 times around
             if phi0 >= self.tokamak.injectionPhiTor:
-                phi1 = phi0 - 2.*np.pi
+                phi1 = phi0 - 2.0 * np.pi
             else:
-                phi1 = phi0 + 2.*np.pi   
+                phi1 = phi0 + 2.0 * np.pi
 
             # next we need the R,Z position of our helical structure at this phi
             flR, flZ = self.tokamak.find_RZ_Fline(Phi=phi1)
 
-            # bivariate normal distribution in poloidal plane. 
-            # integrated over dR and dZ this function returns 1. 
-            localEmis1 = (1 / (2 * np.pi * self.polSigma**2)
-                          * math.exp(-0.5 * ((R - flR)**2 + (Z - flZ)**2) / self.polSigma**2))
+            # bivariate normal distribution in poloidal plane.
+            # integrated over dR and dZ this function returns 1.
+            localEmis1 = (
+                1
+                / (2 * np.pi * self.polSigma**2)
+                * math.exp(-0.5 * ((R - flR) ** 2 + (Z - flZ) ** 2) / self.polSigma**2)
+            )
 
         return localEmis0 + localEmis1
-        
-        
-    def save_RadDist(self, RoundDec = 2):
-        #[saves radiation distribution to a file]
-        
+
+    def save_RadDist(self, RoundDec=2):
+        # [saves radiation distribution to a file]
+
         properties = self.__dict__.copy()
         properties = self.prepare_for_JSON(properties)
-        
-        saveFileName = join(self.saveFileFolder ,"helical_shot_") + str(self.shotnumber)\
-        + "_pSig_" + str(round(self.polSigma, RoundDec)).replace('.', '_')\
-        + "_t_" + str(round(self.time, RoundDec)).replace('.', '_')\
-        + "_R_" + str(round(self.startR, RoundDec)).replace('.', '_')\
-        + "_Z_" + str(round(self.startZ, RoundDec)).replace('.', '_').replace('-', 'neg')\
-        + ".txt"
-          
-        with open(saveFileName, 'w') as save_file:
-             save_file.write(json.dumps(properties))
+
+        saveFileName = (
+            join(self.saveFileFolder, "helical_shot_")
+            + str(self.shotnumber)
+            + "_pSig_"
+            + str(round(self.polSigma, RoundDec)).replace(".", "_")
+            + "_t_"
+            + str(round(self.time, RoundDec)).replace(".", "_")
+            + "_R_"
+            + str(round(self.startR, RoundDec)).replace(".", "_")
+            + "_Z_"
+            + str(round(self.startZ, RoundDec)).replace(".", "_").replace("-", "neg")
+            + ".txt"
+        )
+
+        with open(saveFileName, "w") as save_file:
+            save_file.write(json.dumps(properties))
+
 
 class ElongatedHelical(RadDist):
     # this class will have specifically helical radiation distributions
-    def __init__(self, NumBins = 18, Tokamak = None,\
-                 Mode = "Analysis", LoadFileName = None,\
-                 StartR = 2.96, StartZ = 0.0, PolSigma = 0.15,\
-                 Elongation=1.0, Zoffset = 0.0,\
-                 ShotNumber = None, Time=0, SaveFileFolder=None, TorSegmented=False):
-        super(ElongatedHelical, self).__init__(NumBins = NumBins, NumPuncs = 2,\
-                 Tokamak = Tokamak, Mode = Mode,\
-                 LoadFileName = LoadFileName,\
-                 SaveFileFolder=SaveFileFolder, TorSegmented=TorSegmented)
-    
+    def __init__(
+        self,
+        NumBins=18,
+        Tokamak=None,
+        Mode="Analysis",
+        LoadFileName=None,
+        StartR=2.96,
+        StartZ=0.0,
+        PolSigma=0.15,
+        Elongation=1.0,
+        Zoffset=0.0,
+        ShotNumber=None,
+        Time=0,
+        SaveFileFolder=None,
+        TorSegmented=False,
+    ):
+        super(ElongatedHelical, self).__init__(
+            NumBins=NumBins,
+            NumPuncs=2,
+            Tokamak=Tokamak,
+            Mode=Mode,
+            LoadFileName=LoadFileName,
+            SaveFileFolder=SaveFileFolder,
+            TorSegmented=TorSegmented,
+        )
+
         if LoadFileName == None:
             self.startR = StartR
             self.startZ = StartZ
@@ -1449,35 +2041,39 @@ class ElongatedHelical(RadDist):
                 self.zoffset = properties["zoffset"]
             else:
                 self.zoffset = 0.0
-            
+
         self.distType = "ElongatedHelical"
-        
+
         if Mode == "Build":
             self.make_build_mode()
-            
+
     def make_build_mode(self):
-        self.tokamak.set_fieldline(StartR = self.startR, StartZ = self.startZ,\
-            StartPhi = self.tokamak.injectionPhiTor, FlineShotNumber = self.shotnumber)
-    
-    def evaluate(self, x,y,z, EvalFirstPunc, EvalSecondPunc):
+        self.tokamak.set_fieldline(
+            StartR=self.startR,
+            StartZ=self.startZ,
+            StartPhi=self.tokamak.injectionPhiTor,
+            FlineShotNumber=self.shotnumber,
+        )
+
+    def evaluate(self, x, y, z, EvalFirstPunc, EvalSecondPunc):
         # Return the emissivity (W/m^3/rad) at the point (x,y,z) according to this
         # instantiation of Emis3D. This function works only with scalar values of x, y and z.
 
         # first we need to convert from x,y,z to R,Z,phi
         Z = z
-        R, phi0 = XY_To_RPhi(x,y)
+        R, phi0 = XY_To_RPhi(x, y)
         # readjust range of phi to center on injector location
         if phi0 <= self.tokamak.injectionPhiTor - np.pi:
-            phi0 = phi0 + 2.*np.pi
+            phi0 = phi0 + 2.0 * np.pi
 
         localEmis0 = 0.0
         localEmis1 = 0.0
-        vertExtendParam = 3.0 # for vertical extension of plasma... hardcoded for now
+        vertExtendParam = 3.0  # for vertical extension of plasma... hardcoded for now
         if EvalFirstPunc:
             # next we need the R,Z position of our helical structure at this phi
             flR, flZ = self.tokamak.find_RZ_Fline(Phi=phi0)
 
-            # now for bivariate normal distribution in poloidal plane. 
+            # now for bivariate normal distribution in poloidal plane.
             # elongated in approximate poloidal direction of field line
 
             # first we need to decompose (R,Z) in terms of parallel/perpendicular
@@ -1486,31 +2082,40 @@ class ElongatedHelical(RadDist):
             # "cent0" = (major radius, zoffset), "cent1" = (flR, flZ), "point" = (R,Z)
             cent0ToCent1Vec = [flR - self.tokamak.majorRadius, flZ - self.zoffset]
             cent0ToCent1Vec[1] = cent0ToCent1Vec[1] / vertExtendParam
-            cent0ToCent1VecMag = math.sqrt(cent0ToCent1Vec[0]**2 + cent0ToCent1Vec[1]**2)
-            cent0ToCent1VecNormed = [x/cent0ToCent1VecMag\
-                              for x in cent0ToCent1Vec]
+            cent0ToCent1VecMag = math.sqrt(
+                cent0ToCent1Vec[0] ** 2 + cent0ToCent1Vec[1] ** 2
+            )
+            cent0ToCent1VecNormed = [x / cent0ToCent1VecMag for x in cent0ToCent1Vec]
             perpVecNormed = [-cent0ToCent1VecNormed[1], cent0ToCent1VecNormed[0]]
             cent1ToPointVec = [R - flR, Z - flZ]
-            paralleldist = cent1ToPointVec[0] * cent0ToCent1VecNormed[0] +\
-                cent1ToPointVec[1] * cent0ToCent1VecNormed[1]
-            perpdist = cent1ToPointVec[0] * perpVecNormed[0] +\
-                cent1ToPointVec[1] * perpVecNormed[1]
-            
-            localEmis0 = ((1.0 / (2.0 * np.pi * self.elongation * (self.polSigma**2)))\
-                * math.exp(-0.5 * (perpdist**2) / (self.polSigma*self.elongation)**2)\
-                * math.exp(-0.5 * (paralleldist**2) / self.polSigma**2))
+            paralleldist = (
+                cent1ToPointVec[0] * cent0ToCent1VecNormed[0]
+                + cent1ToPointVec[1] * cent0ToCent1VecNormed[1]
+            )
+            perpdist = (
+                cent1ToPointVec[0] * perpVecNormed[0]
+                + cent1ToPointVec[1] * perpVecNormed[1]
+            )
+
+            localEmis0 = (
+                (1.0 / (2.0 * np.pi * self.elongation * (self.polSigma**2)))
+                * math.exp(
+                    -0.5 * (perpdist**2) / (self.polSigma * self.elongation) ** 2
+                )
+                * math.exp(-0.5 * (paralleldist**2) / self.polSigma**2)
+            )
 
         if EvalSecondPunc:
             # this is the setup for 2 times around
             if phi0 >= self.tokamak.injectionPhiTor:
-                phi1 = phi0 - 2.*np.pi
+                phi1 = phi0 - 2.0 * np.pi
             else:
-                phi1 = phi0 + 2.*np.pi   
+                phi1 = phi0 + 2.0 * np.pi
 
             # next we need the R,Z position of our helical structure at this phi
             flR, flZ = self.tokamak.find_RZ_Fline(Phi=phi1)
 
-            # now for bivariate normal distribution in poloidal plane. 
+            # now for bivariate normal distribution in poloidal plane.
             # elongated in approximate poloidal direction of field line
 
             # first we need to decompose (R,Z) in terms of parallel/perpendicular
@@ -1519,50 +2124,82 @@ class ElongatedHelical(RadDist):
             # "cent0" = (major radius, zoffset), "cent1" = (flR, flZ), "point" = (R,Z)
             cent0ToCent1Vec = [flR - self.tokamak.majorRadius, flZ - self.zoffset]
             cent0ToCent1Vec[1] = cent0ToCent1Vec[1] / vertExtendParam
-            cent0ToCent1VecMag = math.sqrt(cent0ToCent1Vec[0]**2 + cent0ToCent1Vec[1]**2)
-            cent0ToCent1VecNormed = [x/cent0ToCent1VecMag\
-                              for x in cent0ToCent1Vec]
+            cent0ToCent1VecMag = math.sqrt(
+                cent0ToCent1Vec[0] ** 2 + cent0ToCent1Vec[1] ** 2
+            )
+            cent0ToCent1VecNormed = [x / cent0ToCent1VecMag for x in cent0ToCent1Vec]
             perpVecNormed = [-cent0ToCent1VecNormed[1], cent0ToCent1VecNormed[0]]
             cent1ToPointVec = [R - flR, Z - flZ]
-            paralleldist = cent1ToPointVec[0] * cent0ToCent1VecNormed[0] +\
-                cent1ToPointVec[1] * cent0ToCent1VecNormed[1]
-            perpdist = cent1ToPointVec[0] * perpVecNormed[0] +\
-                cent1ToPointVec[1] * perpVecNormed[1]
-            
-            localEmis1 = ((1.0 / (2.0 * np.pi * self.elongation * self.polSigma**2))\
-                * math.exp(-0.5 * (perpdist**2) / (self.polSigma*self.elongation)**2)\
-                * math.exp(-0.5 * (paralleldist**2) / self.polSigma**2))
+            paralleldist = (
+                cent1ToPointVec[0] * cent0ToCent1VecNormed[0]
+                + cent1ToPointVec[1] * cent0ToCent1VecNormed[1]
+            )
+            perpdist = (
+                cent1ToPointVec[0] * perpVecNormed[0]
+                + cent1ToPointVec[1] * perpVecNormed[1]
+            )
+
+            localEmis1 = (
+                (1.0 / (2.0 * np.pi * self.elongation * self.polSigma**2))
+                * math.exp(
+                    -0.5 * (perpdist**2) / (self.polSigma * self.elongation) ** 2
+                )
+                * math.exp(-0.5 * (paralleldist**2) / self.polSigma**2)
+            )
 
         return localEmis0 + localEmis1
-            
-    def save_RadDist(self, RoundDec = 2):
-        #[saves radiation distribution to a file]
-        
+
+    def save_RadDist(self, RoundDec=2):
+        # [saves radiation distribution to a file]
+
         properties = self.__dict__.copy()
         properties = self.prepare_for_JSON(properties)
-        
-        saveFileName = join(self.saveFileFolder ,"ehelical_shot_") + str(self.shotnumber)\
-        + "_pSig_" + str(round(self.polSigma, RoundDec)).replace('.', '_')\
-        + "_t_" + str(round(self.time, RoundDec)).replace('.', '_')\
-        + "_R_" + str(round(self.startR, RoundDec)).replace('.', '_')\
-        + "_Z_" + str(round(self.startZ, RoundDec)).replace('.', '_').replace('-', 'neg')\
-        + "_e_" + str(self.elongation).replace('.', '_')\
-        + ".txt"
-          
-        with open(saveFileName, 'w') as save_file:
-             save_file.write(json.dumps(properties))
+
+        saveFileName = (
+            join(self.saveFileFolder, "ehelical_shot_")
+            + str(self.shotnumber)
+            + "_pSig_"
+            + str(round(self.polSigma, RoundDec)).replace(".", "_")
+            + "_t_"
+            + str(round(self.time, RoundDec)).replace(".", "_")
+            + "_R_"
+            + str(round(self.startR, RoundDec)).replace(".", "_")
+            + "_Z_"
+            + str(round(self.startZ, RoundDec)).replace(".", "_").replace("-", "neg")
+            + "_e_"
+            + str(self.elongation).replace(".", "_")
+            + ".txt"
+        )
+
+        with open(saveFileName, "w") as save_file:
+            save_file.write(json.dumps(properties))
+
 
 class Sphere(RadDist):
     # these structures are uniform spheres of emissivity
-    def __init__(self, NumBins = 18, Tokamak = None,\
-               Mode = "Analysis", LoadFileName = None,\
-               StartR = 1.2, StartZ = 0.0, Radius = .5,\
-               Phi = 0, SaveFileFolder=None, TorSegmented=False):
-        super(Sphere, self).__init__(NumBins = NumBins,\
-             NumPuncs = 1, Tokamak = Tokamak,\
-             Mode = Mode, LoadFileName = LoadFileName,\
-             SaveFileFolder=SaveFileFolder, TorSegmented=TorSegmented)
-        
+    def __init__(
+        self,
+        NumBins=18,
+        Tokamak=None,
+        Mode="Analysis",
+        LoadFileName=None,
+        StartR=1.2,
+        StartZ=0.0,
+        Radius=0.5,
+        Phi=0,
+        SaveFileFolder=None,
+        TorSegmented=False,
+    ):
+        super(Sphere, self).__init__(
+            NumBins=NumBins,
+            NumPuncs=1,
+            Tokamak=Tokamak,
+            Mode=Mode,
+            LoadFileName=LoadFileName,
+            SaveFileFolder=SaveFileFolder,
+            TorSegmented=TorSegmented,
+        )
+
         if LoadFileName == None:
             if StartR == None:
                 self.startR = self.tokamak.majorRadius
@@ -1578,45 +2215,50 @@ class Sphere(RadDist):
             self.startZ = properties["startZ"]
             self.radius = properties["radius"]
             self.phi = properties["phi"]
-        
+
         self.distType = "Sphere"
-        
+
     def make_build_mode(self):
         # toroidals need no additions for build mode
         pass
-        
-   
-    def evaluate(self, x,y,z, EvalFirstPunc, EvalSecondPunc):
-        
+
+    def evaluate(self, x, y, z, EvalFirstPunc, EvalSecondPunc):
+
         # first we need to convert from x,y,z to R,Z,phi
-        
-        
+
         startX, startY = RPhi_To_XY(self.startR, self.phi)
-        
 
         if EvalFirstPunc:
-            #Any point outside of major radius of Tokamak has no emisivisty  
-            if((x-startX)**2 + (y-startY)**2 + (z-self.startZ)**2 < self.radius**2):
+            # Any point outside of major radius of Tokamak has no emisivisty
+            if (x - startX) ** 2 + (y - startY) ** 2 + (
+                z - self.startZ
+            ) ** 2 < self.radius**2:
                 localEmis = 1
-            else: 
+            else:
                 localEmis = 0
             return localEmis
-            
+
         if EvalSecondPunc:
-            
+
             return 0.0
-        
-    def save_RadDist(self, RoundDec = 2):
-        #[saves radiation distribution to a file]
-        
+
+    def save_RadDist(self, RoundDec=2):
+        # [saves radiation distribution to a file]
+
         properties = self._dict_
         properties = self.prepare_for_JSON(properties)
-        
-        saveFileName = join(self.saveFileFolder,"sphere_radius_") + str(round(self.radius, RoundDec)).replace('.', '_')\
-        + "phi" + str(round(self.phi, RoundDec)).replace('.', '_')\
-        + "R" + str(round(self.startR, RoundDec)).replace('.', '_')\
-        + "Z" + str(round(self.startZ, RoundDec)).replace('.', '_').replace('-', 'neg')\
-        + ".txt"
-          
-        with open(saveFileName, 'w') as save_file:
-             save_file.write(json.dumps(properties))
+
+        saveFileName = (
+            join(self.saveFileFolder, "sphere_radius_")
+            + str(round(self.radius, RoundDec)).replace(".", "_")
+            + "phi"
+            + str(round(self.phi, RoundDec)).replace(".", "_")
+            + "R"
+            + str(round(self.startR, RoundDec)).replace(".", "_")
+            + "Z"
+            + str(round(self.startZ, RoundDec)).replace(".", "_").replace("-", "neg")
+            + ".txt"
+        )
+
+        with open(saveFileName, "w") as save_file:
+            save_file.write(json.dumps(properties))


### PR DESCRIPTION
Vectorized self.power_per_bin_calc_fast within the RadDist class. Implemented it with the helical radDist. The program now creates the powerPerBin arrays on the order of 30 times faster for a given field line. The D3D version also parallelizes creating radDists, so that is also done much faster. 

Time savings:

![Screenshot 2025-02-27 at 3 24 44 PM](https://github.com/user-attachments/assets/08124b72-9ae8-4a74-bbfb-7d8b72dc7b55)


Comparison between old and new:

![Screenshot 2025-02-27 at 3 25 40 PM](https://github.com/user-attachments/assets/7076c480-0004-4f2e-9ca1-44c98b38be6b)


Plot comparing old and new (they are the same):
![Vectorized_power_per_bin_calc](https://github.com/user-attachments/assets/9a5097c5-308f-4384-8be7-af87f04f5292)


My program editor also automatically formatted the Emis3D and RadDist packages based on the black code formatter, which is why there are so many changes. Information about the code formatter can be found here: https://pypi.org/project/black/